### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Use tabs for indentation on go files
+[*.{go,Makefile}]
+indent_style = tab
+
+# Use 2 space indentation for markdown and json
+[*.{md,json}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Added a .editorconfig file to formalize code formating through the project.

#### Rules added
* tab indentation for .go and Makefile files;
* 2 space indentation for markdown and json files.