### PR TITLE
Reverts internal URL escaping

### DIFF
--- a/components/ConnectionForm.go
+++ b/components/ConnectionForm.go
@@ -50,7 +50,7 @@ func NewConnectionForm(connectionPages *models.ConnectionPages) *ConnectionForm 
 	statusText.SetBorderPadding(0, 1, 0, 0)
 
 	wrapper.AddItem(addForm, 0, 1, true)
-	wrapper.AddItem(statusText, 2, 0, false)
+	wrapper.AddItem(statusText, 3, 0, false)
 	wrapper.AddItem(buttonsWrapper, 1, 0, false)
 
 	form := &ConnectionForm{
@@ -149,11 +149,26 @@ func (form *ConnectionForm) inputCapture(connectionPages *models.ConnectionPages
 }
 
 func (form *ConnectionForm) testConnection(connectionString string) {
+	parsed, err := helpers.ParseConnectionString(connectionString)
+	if err != nil {
+		form.StatusText.SetText(err.Error()).SetTextStyle(tcell.StyleDefault.Foreground(tcell.ColorRed))
+		return
+	}
+
 	form.StatusText.SetText("Connecting...").SetTextColor(tcell.ColorGreen)
 
-	db := drivers.MySQL{}
+	var db drivers.Driver
 
-	err := db.TestConnection(connectionString)
+	switch parsed.Driver {
+	case "mysql":
+		db = &drivers.MySQL{}
+	case "postgres":
+		db = &drivers.Postgres{}
+	case "sqlite3":
+		db = &drivers.SQLite{}
+	}
+
+	err = db.TestConnection(connectionString)
 
 	if err != nil {
 		form.StatusText.SetText(err.Error()).SetTextStyle(tcell.StyleDefault.Foreground(tcell.ColorRed))

--- a/components/ConnectionForm.go
+++ b/components/ConnectionForm.go
@@ -84,26 +84,21 @@ func (form *ConnectionForm) inputCapture(connectionPages *models.ConnectionPages
 				form.StatusText.SetText(err.Error()).SetTextStyle(tcell.StyleDefault.Foreground(tcell.ColorRed))
 				return event
 			} else {
-				password, _ := parsed.User.Password()
+
 				databases, _ := helpers.LoadConnections()
 				newDatabases := make([]models.Connection, len(databases))
+
+				parsedDatabaseData := models.Connection{
+					Name:     connectionName,
+					Provider: parsed.Driver,
+					DBName:   helpers.ParsedDBName(parsed.Path),
+					URL:      connectionString,
+				}
 
 				switch form.Action {
 				case "create":
 
-					database := models.Connection{
-						Name:     connectionName,
-						Provider: parsed.Driver,
-						User:     parsed.User.Username(),
-						Password: password,
-						Host:     parsed.Hostname(),
-						Port:     parsed.Port(),
-						Query:    parsed.Query().Encode(),
-						DBName:   helpers.ParsedDBName(parsed.Path),
-						DSN:      parsed.DSN,
-					}
-
-					newDatabases = append(databases, database)
+					newDatabases = append(databases, parsedDatabaseData)
 					err := helpers.SaveConnectionConfig(newDatabases)
 					if err != nil {
 						form.StatusText.SetText(err.Error()).SetTextStyle(tcell.StyleDefault.Foreground(tcell.ColorRed))
@@ -113,18 +108,20 @@ func (form *ConnectionForm) inputCapture(connectionPages *models.ConnectionPages
 				case "edit":
 					newDatabases = make([]models.Connection, len(databases))
 					row, _ := ConnectionListTable.GetSelection()
+
 					for i, database := range databases {
 						if i == row {
+							newDatabases[i] = parsedDatabaseData
 
-							newDatabases[i].Name = connectionName
-							newDatabases[i].Provider = database.Provider
-							newDatabases[i].User = parsed.User.Username()
-							newDatabases[i].Password, _ = parsed.User.Password()
-							newDatabases[i].Host = parsed.Hostname()
-							newDatabases[i].Port = parsed.Port()
-							newDatabases[i].Query = parsed.Query().Encode()
-							newDatabases[i].DBName = helpers.ParsedDBName(parsed.Path)
-							newDatabases[i].DSN = parsed.DSN
+							// newDatabases[i].Name = connectionName
+							// newDatabases[i].Provider = database.Provider
+							// newDatabases[i].User = parsed.User.Username()
+							// newDatabases[i].Password, _ = parsed.User.Password()
+							// newDatabases[i].Host = parsed.Hostname()
+							// newDatabases[i].Port = parsed.Port()
+							// newDatabases[i].Query = parsed.Query().Encode()
+							// newDatabases[i].DBName = helpers.ParsedDBName(parsed.Path)
+							// newDatabases[i].DSN = parsed.DSN
 						} else {
 							newDatabases[i] = database
 						}
@@ -137,6 +134,7 @@ func (form *ConnectionForm) inputCapture(connectionPages *models.ConnectionPages
 
 					}
 				}
+
 				ConnectionListTable.SetConnections(newDatabases)
 				connectionPages.SwitchToPage("Connections")
 			}

--- a/components/ConnectionForm.go
+++ b/components/ConnectionForm.go
@@ -1,8 +1,6 @@
 package components
 
 import (
-	"net/url"
-
 	"github.com/jorgerojas26/lazysql/drivers"
 	"github.com/jorgerojas26/lazysql/helpers"
 	"github.com/jorgerojas26/lazysql/models"
@@ -78,7 +76,7 @@ func (form *ConnectionForm) inputCapture(connectionPages *models.ConnectionPages
 				return event
 			}
 
-			connectionString := helpers.EscapeConnectionString(form.GetFormItem(1).(*tview.InputField).GetText())
+			connectionString := form.GetFormItem(1).(*tview.InputField).GetText()
 
 			parsed, err := helpers.ParseConnectionString(connectionString)
 
@@ -153,31 +151,9 @@ func (form *ConnectionForm) inputCapture(connectionPages *models.ConnectionPages
 func (form *ConnectionForm) testConnection(connectionString string) {
 	form.StatusText.SetText("Connecting...").SetTextColor(tcell.ColorGreen)
 
-	parsed, err := helpers.ParseConnectionString(connectionString)
-	if err != nil {
-		panic(err.Error())
-	}
-
-	password, _ := parsed.User.Password()
-	DBName := helpers.ParsedDBName(parsed.Path)
-
-	escapedConnection := models.Connection{
-		Name:     "",
-		Provider: parsed.Driver,
-		User:     url.QueryEscape(parsed.User.Username()),
-		Password: password,
-		Host:     parsed.Host,
-		Port:     parsed.Port(),
-		DBName:   DBName,
-		Query:    url.QueryEscape(parsed.Query().Encode()),
-		DSN:      url.QueryEscape(parsed.DSN),
-	}
-
-	escapedConnectionString := helpers.ConnectionToURL(&escapedConnection)
-
 	db := drivers.MySQL{}
 
-	err = db.TestConnection(escapedConnectionString)
+	err := db.TestConnection(connectionString)
 
 	if err != nil {
 		form.StatusText.SetText(err.Error()).SetTextStyle(tcell.StyleDefault.Foreground(tcell.ColorRed))

--- a/components/ConnectionSelection.go
+++ b/components/ConnectionSelection.go
@@ -55,7 +55,7 @@ func NewConnectionSelection(connectionForm *ConnectionForm, connectionPages *mod
 	statusText.SetBorderPadding(0, 1, 0, 0)
 
 	wrapper.AddItem(ConnectionListTable, 0, 1, true)
-	wrapper.AddItem(statusText, 2, 0, false)
+	wrapper.AddItem(statusText, 3, 0, false)
 	wrapper.AddItem(buttonsWrapper, 1, 0, false)
 
 	cs := &ConnectionSelection{
@@ -143,7 +143,12 @@ func NewConnectionSelection(connectionForm *ConnectionForm, connectionPages *mod
 }
 
 func (cs *ConnectionSelection) connect(connectionUrl string, connectionTitle string) {
-	parsed, _ := helpers.ParseConnectionString(connectionUrl)
+	parsed, err := helpers.ParseConnectionString(connectionUrl)
+	if err != nil {
+		cs.StatusText.SetText(err.Error()).SetTextStyle(tcell.StyleDefault.Foreground(tcell.ColorRed))
+		App.Draw()
+		return
+	}
 
 	if MainPages.HasPage(connectionUrl) {
 		MainPages.SwitchToPage(connectionUrl)

--- a/components/Home.go
+++ b/components/Home.go
@@ -24,7 +24,12 @@ type Home struct {
 }
 
 func NewHomePage(name string, dbdriver drivers.Driver) *Home {
-	dbName := helpers.GetDBName(name)
+	parsed, err := helpers.ParseConnectionString(name)
+	if err != nil {
+		panic(err.Error())
+	}
+
+	dbName := helpers.ParsedDBName(parsed.Path)
 
 	tree := NewTree(dbName, dbdriver)
 	tabbedPane := NewTabbedPane()

--- a/components/Home.go
+++ b/components/Home.go
@@ -24,12 +24,7 @@ type Home struct {
 }
 
 func NewHomePage(name string, dbdriver drivers.Driver) *Home {
-	parsed, err := helpers.ParseConnectionString(name)
-	if err != nil {
-		panic(err.Error())
-	}
-
-	dbName := helpers.ParsedDBName(parsed.Path)
+	dbName := helpers.ParsedDBName(name)
 
 	tree := NewTree(dbName, dbdriver)
 	tabbedPane := NewTabbedPane()

--- a/drivers/mysql.go
+++ b/drivers/mysql.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/jorgerojas26/lazysql/helpers"
 	"github.com/jorgerojas26/lazysql/models"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -23,9 +22,7 @@ func (db *MySQL) TestConnection(urlstr string) (err error) {
 }
 
 func (db *MySQL) Connect(urlstr string) (err error) {
-	parsed, _ := helpers.ParseConnectionString(urlstr)
-
-	db.SetProvider(parsed.Driver)
+	db.SetProvider("mysql")
 
 	db.Connection, err = dburl.Open(urlstr)
 	if err != nil {

--- a/drivers/postgres.go
+++ b/drivers/postgres.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/jorgerojas26/lazysql/helpers"
 	"github.com/jorgerojas26/lazysql/models"
 	"github.com/xo/dburl"
 
@@ -19,9 +18,7 @@ type Postgres struct {
 }
 
 func (db *Postgres) Connect(urlstr string) (err error) {
-	parsed, _ := helpers.ParseConnectionString(urlstr)
-
-	db.SetProvider(parsed.Driver)
+	db.SetProvider("postgres")
 
 	db.Connection, err = dburl.Open(urlstr)
 

--- a/drivers/sqlite.go
+++ b/drivers/sqlite.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/jorgerojas26/lazysql/helpers"
 	"github.com/jorgerojas26/lazysql/models"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/xo/dburl"
@@ -22,9 +21,7 @@ func (db *SQLite) TestConnection(urlstr string) (err error) {
 }
 
 func (db *SQLite) Connect(urlstr string) (err error) {
-	parsed, _ := helpers.ParseConnectionString(urlstr)
-
-	db.SetProvider(parsed.Driver)
+	db.SetProvider("sqlite3")
 
 	db.Connection, err = dburl.Open(urlstr)
 

--- a/helpers/utils.go
+++ b/helpers/utils.go
@@ -1,54 +1,13 @@
 package helpers
 
 import (
-	"fmt"
-	"net/url"
 	"strings"
 
-	"github.com/jorgerojas26/lazysql/models"
 	"github.com/xo/dburl"
 )
 
 func ParseConnectionString(url string) (*dburl.URL, error) {
 	return dburl.Parse(url)
-}
-
-func EscapeConnectionString(urlstr string) string {
-	connectionString := urlstr
-
-	splitConnection := strings.Split(connectionString, "://")
-
-	if len(splitConnection) > 1 {
-		if strings.Contains(connectionString, "?") {
-			splitPath := strings.Split(splitConnection[1], "?")
-
-			connectionString = splitConnection[0] + "://" + url.PathEscape(splitPath[0]) + "?" + splitPath[1]
-		} else {
-			connectionString = splitConnection[0] + "://" + url.PathEscape(splitConnection[1])
-		}
-	}
-	return connectionString
-}
-
-func ConnectionToURL(connection *models.Connection) string {
-	connectionUrl := fmt.Sprintf("%s://%s:%s@%s:%s", connection.Provider, connection.User, connection.Password, connection.Host, connection.Port)
-
-	queryParams := connection.Query
-	dbNamePath := connection.DBName
-
-	if connection.Provider == "sqlite3" {
-		connectionUrl = fmt.Sprintf("file:%s", connection.DSN)
-	} else {
-		if dbNamePath != "" {
-			connectionUrl = fmt.Sprintf("%s/%s", connectionUrl, dbNamePath)
-		}
-
-		if queryParams != "" {
-			connectionUrl = fmt.Sprintf("%s?%s", connectionUrl, queryParams)
-		}
-
-	}
-	return connectionUrl
 }
 
 func GetDBName(url string) string {

--- a/models/models.go
+++ b/models/models.go
@@ -8,13 +8,8 @@ import (
 type Connection struct {
 	Name     string
 	Provider string
-	User     string
-	Password string
-	Host     string
-	Port     string
-	Query    string
 	DBName   string
-	DSN      string
+	URL      string
 }
 
 type StateChange struct {


### PR DESCRIPTION
This resolves #25, #30, #31, #32, #33, #34.

The user is now responsible of properly escaping the url connection string.

Lazysql rely primarily on [xo/dburl](https://github.com/xo/dburl?tab=readme-ov-file#url-parsing-rules), and as such, parsing or opening database connection URLs with Lazysql are subject to the same rules, conventions, and semantics.

For examples of supported URLs please see: https://github.com/xo/dburl?tab=readme-ov-file#example-urls

