### PR TITLE
refactor: replaces "where" logic in DML statements

### DIFF
--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -14,8 +14,8 @@ type Driver interface {
 	GetForeignKeys(table string) ([][]string, error)
 	GetIndexes(table string) ([][]string, error)
 	GetRecords(table, where, sort string, offset, limit int) ([][]string, int, error)
-	UpdateRecord(table, column, value, id string) error
-	DeleteRecord(table string, id string) error
+	UpdateRecord(table, column, value, primaryKeyColumnName, primaryKeyValue string) error
+	DeleteRecord(table string, primaryKeyColumnName, primaryKeyValue string) error
 	ExecuteDMLStatement(query string) (string, error)
 	ExecuteQuery(query string) ([][]string, error)
 	ExecutePendingChanges(changes []models.DbDmlChange, inserts []models.DbInsert) error

--- a/models/models.go
+++ b/models/models.go
@@ -23,18 +23,28 @@ type ConnectionPages struct {
 }
 
 type DbDmlChange struct {
-	Type   string
-	Table  string
-	Column string
-	Value  string
-	RowId  string
-	Option int
+	Type                 string
+	Table                string
+	Column               string
+	Value                string
+	PrimaryKeyColumnName string
+	PrimaryKeyValue      string
+	Option               int
 }
 
 type DbInsert struct {
-	Table   string
-	Columns []string
-	Values  []string
-	Option  int
-	RowId   uuid.UUID
+	Table           string
+	Columns         []string
+	Values          []string
+	Option          int
+	PrimaryKeyValue uuid.UUID
+}
+
+type DatabaseTableColumn struct {
+	Field   string
+	Type    string
+	Null    string
+	Key     string
+	Default string
+	Extra   string
 }


### PR DESCRIPTION
DML statements "where" condition were using a hardcoded "id" column, which of course did not work for tables that do not have an "id" column.

So, instead of hardcoding the where condition, now we find a primary key column name and for every DML statement we pass that column name and value, so it is required to have a primary key on the table to perform DML updates in this version.

Maybe later we can improve that logic requesting the user to introduce the `where` condition in a popup if there is no a primary key, but for now i think this works.

Fixes #35