### PR TITLE
feat: Add support for different schemas in Postgresql driver

### DIFF
--- a/components/Tree.go
+++ b/components/Tree.go
@@ -152,7 +152,7 @@ func (tree *Tree) updateNodes(children map[string][]string, node *tview.TreeNode
 		for _, child := range values {
 			childNode := tview.NewTreeNode(child)
 			childNode.SetExpanded(defaultExpanded)
-			childNode.SetReference(node.GetText())
+			childNode.SetReference(fmt.Sprintf("%s.%s", node.GetText(), key))
 			childNode.SetColor(tview.Styles.SecondaryTextColor)
 			if rootNode != nil {
 				rootNode.AddChild(childNode)


### PR DESCRIPTION
**Add support for different schemas in postgresql and add support for uuid primary keys**

### Problem

I have two schemas in the same postgresql database with the same table name. One table is in the public schema, and the other in a test schema. Currently records are only fetched from the table in the public schema and constraints and foreign keys are fetched for both tables.

Also, when editing a cell, the current code uses next_val to find the primary key, but my table uses uuids as the primary key, so no primary key is found resulting in a missing where clause.

### Solution

Add schema prefix to all operations in the postgres driver.

Don't rely on next_val for the primary key column and instead look for a column with the primary key constraint.