### PR TITLE
feat: enable mouse actions when interact with lazysql terminal UI

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,7 +13,10 @@ import (
 func main() {
 	mysql.SetLogger(log.New(io.Discard, "", 0))
 
-	if err := app.App.SetRoot(components.MainPages, true).Run(); err != nil {
+	if err := app.App.
+		SetRoot(components.MainPages, true).
+		EnableMouse(true).
+		Run(); err != nil {
 		panic(err)
 	}
 }


### PR DESCRIPTION
When I use the lazygit, I find that there is a  mouse action feature can be enabled ,  the go package `github.com/rivo/tview` support this function itself , only to add one line code before calling Run() function.  And it seems greate to enable this, then I can use mouse click to check the database and chart.

![gifmaker_me](https://github.com/jorgerojas26/lazysql/assets/56944601/b1a0b0ac-673c-4c4d-8c75-3498274a787f)


