### PR TITLE
feat: add '?' key in order to show help informations

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Support for multiple RDBMS is a work in progress.
 
 | Key       | Action                         |
 | --------- | ------------------------------ |
+| ?         | Help                           |
 | q         | Quit                           |
 | CTRL + e  | Open SQL editor                |
 | Backspace | Return to connection selection |

--- a/components/ConnectionSelection.go
+++ b/components/ConnectionSelection.go
@@ -2,12 +2,11 @@ package components
 
 import (
 	"fmt"
-	"strings"
-
 	"github.com/jorgerojas26/lazysql/app"
 	"github.com/jorgerojas26/lazysql/drivers"
 	"github.com/jorgerojas26/lazysql/helpers"
 	"github.com/jorgerojas26/lazysql/models"
+	"strings"
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
@@ -21,42 +20,36 @@ type ConnectionSelection struct {
 var ConnectionListTable = NewConnectionsTable()
 
 func NewConnectionSelection(connectionForm *ConnectionForm, connectionPages *models.ConnectionPages) *ConnectionSelection {
-	wrapper := tview.NewFlex()
-
-	wrapper.SetDirection(tview.FlexColumnCSS)
 
 	buttonsWrapper := tview.NewFlex().SetDirection(tview.FlexRowCSS)
 
-	newButton := tview.NewButton("[darkred]N[black]ew")
-	newButton.SetStyle(tcell.StyleDefault.Background(tcell.ColorGhostWhite))
-	buttonsWrapper.AddItem(newButton, 0, 1, false)
-	buttonsWrapper.AddItem(nil, 1, 0, false)
+	newButton := tview.NewButton("[darkred]N[black]ew").
+		SetStyle(tcell.StyleDefault.Background(tcell.ColorGhostWhite))
+	buttonsWrapper.AddItem(newButton, 0, 1, false).AddItem(nil, 1, 0, false)
 
-	connectButton := tview.NewButton("[darkred]C[black]onnect")
-	connectButton.SetStyle(tcell.StyleDefault.Background(tcell.ColorGhostWhite))
-	buttonsWrapper.AddItem(connectButton, 0, 1, false)
-	buttonsWrapper.AddItem(nil, 1, 0, false)
+	connectButton := tview.NewButton("[darkred]C[black]onnect").
+		SetStyle(tcell.StyleDefault.Background(tcell.ColorGhostWhite))
+	buttonsWrapper.AddItem(connectButton, 0, 1, false).AddItem(nil, 1, 0, false)
 
-	editButton := tview.NewButton("[darkred]E[black]dit")
-	editButton.SetStyle(tcell.StyleDefault.Background(tcell.ColorGhostWhite))
-	buttonsWrapper.AddItem(editButton, 0, 1, false)
-	buttonsWrapper.AddItem(nil, 1, 0, false)
+	editButton := tview.NewButton("[darkred]E[black]dit").
+		SetStyle(tcell.StyleDefault.Background(tcell.ColorGhostWhite))
+	buttonsWrapper.AddItem(editButton, 0, 1, false).AddItem(nil, 1, 0, false)
 
-	deleteButton := tview.NewButton("[darkred]D[black]elete")
-	deleteButton.SetStyle(tcell.StyleDefault.Background(tcell.ColorGhostWhite))
-	buttonsWrapper.AddItem(deleteButton, 0, 1, false)
-	buttonsWrapper.AddItem(nil, 1, 0, false)
+	deleteButton := tview.NewButton("[darkred]D[black]elete").
+		SetStyle(tcell.StyleDefault.Background(tcell.ColorGhostWhite))
+	buttonsWrapper.AddItem(deleteButton, 0, 1, false).AddItem(nil, 1, 0, false)
 
-	quitButton := tview.NewButton("[darkred]Q[black]uit")
-	quitButton.SetStyle(tcell.StyleDefault.Background(tcell.ColorGhostWhite))
-	buttonsWrapper.AddItem(quitButton, 0, 1, false)
+	quitButton := tview.NewButton("[darkred]Q[black]uit").
+		SetStyle(tcell.StyleDefault.Background(tcell.ColorGhostWhite))
+	buttonsWrapper.AddItem(quitButton, 0, 1, false).AddItem(nil, 1, 0, false)
 
 	statusText := tview.NewTextView()
 	statusText.SetBorderPadding(0, 1, 0, 0)
 
-	wrapper.AddItem(ConnectionListTable, 0, 1, true)
-	wrapper.AddItem(statusText, 3, 0, false)
-	wrapper.AddItem(buttonsWrapper, 1, 0, false)
+	wrapper := tview.NewFlex().SetDirection(tview.FlexColumnCSS).
+		AddItem(ConnectionListTable, 0, 1, true).
+		AddItem(statusText, 3, 0, false).
+		AddItem(buttonsWrapper, 1, 0, false)
 
 	cs := &ConnectionSelection{
 		Flex:       wrapper,
@@ -65,58 +58,69 @@ func NewConnectionSelection(connectionForm *ConnectionForm, connectionPages *mod
 
 	wrapper.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		connections := ConnectionListTable.GetConnections()
-
-		if len(connections) != 0 {
-			row, _ := ConnectionListTable.GetSelection()
-			selectedConnection := connections[row]
-
-			if event.Rune() == 'c' || event.Key() == tcell.KeyEnter {
-				go cs.Connect(selectedConnection)
-			} else if event.Rune() == 'e' {
-				connectionPages.SwitchToPage("ConnectionForm")
-				connectionForm.GetFormItemByLabel("Name").(*tview.InputField).SetText(selectedConnection.Name)
-				connectionForm.GetFormItemByLabel("URL").(*tview.InputField).SetText(selectedConnection.URL)
-				connectionForm.StatusText.SetText("")
-
-				connectionForm.SetAction("edit")
-				return nil
-
-			} else if event.Rune() == 'd' {
-				confirmationModal := NewConfirmationModal("")
-
-				confirmationModal.SetDoneFunc(func(_ int, buttonLabel string) {
-					MainPages.RemovePage("Confirmation")
-					confirmationModal = nil
-
-					if buttonLabel == "Yes" {
-						newConnections := append(connections[:row], connections[row+1:]...)
-
-						err := helpers.SaveConnectionConfig(newConnections)
-						if err != nil {
-							ConnectionListTable.SetError(err.Error())
-						} else {
-							ConnectionListTable.SetConnections(newConnections)
-						}
-
-					}
-				})
-
-				MainPages.AddPage("Confirmation", confirmationModal, true, true)
-
-				return nil
-			}
+		if len(connections) == 0 {
+			return event
 		}
 
-		if event.Rune() == 'n' {
+		row, _ := ConnectionListTable.GetSelection()
+		selectedConnection := connections[row]
+
+		eventKey := event.Rune()
+		if eventKey == rune(0) {
+			eventKey = rune(event.Key())
+		}
+
+		switch eventKey {
+		case 'c', rune(tcell.KeyEnter):
+			go cs.Connect(selectedConnection)
+
+		case 'e':
+			connectionPages.SwitchToPage("ConnectionForm")
+			connectionForm.GetFormItemByLabel("Name").(*tview.InputField).SetText(selectedConnection.Name)
+			connectionForm.GetFormItemByLabel("URL").(*tview.InputField).SetText(selectedConnection.URL)
+			connectionForm.StatusText.SetText("")
+			connectionForm.SetAction("edit")
+			return nil
+
+		case 'd':
+			confirmationModal := NewConfirmationModal("")
+			confirmationModal.SetDoneFunc(func(_ int, buttonLabel string) {
+				MainPages.RemovePage("Confirmation")
+				confirmationModal = nil
+				if buttonLabel == "Yes" {
+					newConnections := append(connections[:row], connections[row+1:]...)
+					err := helpers.SaveConnectionConfig(newConnections)
+					if err != nil {
+						ConnectionListTable.SetError(err.Error())
+					} else {
+						ConnectionListTable.SetConnections(newConnections)
+					}
+
+				}
+			})
+			MainPages.AddPage("Confirmation", confirmationModal, true, true)
+			return nil
+
+		case 'n':
 			connectionForm.SetAction("create")
 			connectionForm.GetFormItemByLabel("Name").(*tview.InputField).SetText("")
 			connectionForm.GetFormItemByLabel("URL").(*tview.InputField).SetText("")
 			connectionForm.StatusText.SetText("")
 			connectionPages.SwitchToPage("ConnectionForm")
-		} else if event.Rune() == 'q' {
+
+		case '?':
+			HelpModal := NewHelpModal()
+			HelpModal.SetDoneFunc(func(_ int, buttonLabel string) {
+				MainPages.RemovePage("Help")
+				HelpModal = nil
+			})
+			MainPages.AddPage("Help", HelpModal, true, true)
+
+		case 'q':
 			if wrapper.HasFocus() {
 				app.App.Stop()
 			}
+
 		}
 
 		return event

--- a/components/HelpModal.go
+++ b/components/HelpModal.go
@@ -1,0 +1,88 @@
+package components
+
+import (
+	"fmt"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+)
+
+type KeyBindings struct {
+	Global    map[string]string
+	Table     map[string]string
+	Tree      map[string]string
+	SQLEditor map[string]string
+}
+
+func (kb KeyBindings) String() string {
+	var result string
+
+	// Global
+	result += "---Global---\n"
+	for key, value := range kb.Global {
+		result += fmt.Sprintf("%s: %s\n", key, value)
+	}
+
+	// Table
+	result += "\n---Table---\n"
+	for key, value := range kb.Table {
+		result += fmt.Sprintf("%s: %s\n", key, value)
+	}
+
+	// Tree
+	result += "\n---Tree---\n"
+	for key, value := range kb.Tree {
+		result += fmt.Sprintf("%s: %s\n", key, value)
+	}
+
+	// SQLEditor
+	result += "\n---SQLEditor---\n"
+	for key, value := range kb.SQLEditor {
+		result += fmt.Sprintf("%s: %s\n", key, value)
+	}
+	return result
+}
+
+type HelpModal struct {
+	*tview.Modal
+}
+
+func NewHelpModal() *HelpModal {
+	keybindings := KeyBindings{
+		Global: map[string]string{
+			"?":         "Show help informations",
+			"CTRL+e":    "Open SQL editor",
+			"BACKSPACE": "Return to connection selection",
+		},
+		Table: map[string]string{
+			"c":      "Edit table cell",
+			"d":      "Delete row",
+			"o":      "Add row",
+			"/":      "Focus the filter input or SQL editor",
+			"CTRL+s": "Commit changes",
+			">":      "Next page",
+			"<":      "Previous page",
+			"K":      "Sort ASC",
+			"J":      "Sort DESC",
+			"H":      "Focus tree panel",
+			"[":      "Focus previous tab",
+			"]":      "Focus next tab",
+			"X":      "Close current tab",
+		},
+		Tree: map[string]string{
+			"L": "Focus table pane",
+		},
+		SQLEditor: map[string]string{
+			"CTRL+R": "Run the SQL statement",
+		},
+	}
+	modal := tview.NewModal().
+		SetText("Help").
+		AddButtons([]string{"ESC"}).
+		SetBackgroundColor(tcell.ColorBlack).
+		SetTextColor(tview.Styles.PrimaryTextColor).SetText(keybindings.String())
+
+	return &HelpModal{
+		Modal: modal,
+	}
+}


### PR DESCRIPTION
Just like lazygit, when user press '?' key, it prompt a help interface which shows the keybindings,. so I add some code the impliment the similar feature in lazysql. And after testing,  it works in lazysql now .

And also, I modify the README.md to let users know this feature.

Well, I review some of the original code and rewrite some code to make it more readable, but I did't affect any of the major function of lazysql, so it is safe to merge into the main branch 
![5](https://github.com/jorgerojas26/lazysql/assets/56944601/219c6d39-b960-4c2c-bc6c-aea7b8083983)
