### PR TITLE
fix: add keybindings info accroding to source code

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ Support for multiple RDBMS is a work in progress.
 | Key | Action            |
 | --- | ----------------- |
 | L   | Focus table panel |
+| G   | Focus root tree node |
+| g   | Focus last tree node |
 
 ### SQL Editor
 

--- a/README.md
+++ b/README.md
@@ -171,11 +171,11 @@ Support for multiple RDBMS is a work in progress.
 
 ### Tree
 
-| Key | Action            |
-| --- | ----------------- |
-| L   | Focus table panel |
-| G   | Focus root tree node |
-| g   | Focus last tree node |
+| Key | Action                         |
+| --- | ------------------------------ |
+| L   | Focus table panel              |
+| G   | Focus last database tree node  |
+| g   | Focus first database tree node |
 
 ### SQL Editor
 


### PR DESCRIPTION
fix:  according to the source code , when navigate the database and table tree,, there are 2  more keys avaiable， but they are not shown in the README, so I add then in README to let user know this feature


### filename
> **components/Tree.go**
```
tree.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
		switch event.Rune() {
		case 'G':
			childrens := tree.GetRoot().GetChildren()
			lastNode := childrens[len(childrens)-1]

			if lastNode.IsExpanded() {
				childNodes := lastNode.GetChildren()
				lastChildren := childNodes[len(childNodes)-1]
				tree.SetCurrentNode(lastChildren)
			} else {
				tree.SetCurrentNode(lastNode)
			}
		case 'g':
			tree.SetCurrentNode(rootNode)
		}
		return event
	})
```