### PR TITLE
[Feat] Added support for external editor (2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Support for multiple RDBMS is a work in progress.
 | Key          | Action                            |
 | ------------ | --------------------------------- |
 | CTRL + R     | Run the SQL statement             |
-| CTRL + Space | Open external editor(Linux only)  |
+| CTRL + Space | Open external editor (Linux only)  |
 
 Specific editor for lazysql can be set by `$SQL_EDITOR`.
 

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Support for multiple RDBMS is a work in progress.
 | CTRL + Space | Open external editor(Linux only)  |
 
 Specific editor for lazysql can be set by `$SQL_EDITOR`.
+
 Specific terminal for opening editor can be set by `$SQL_TERMINAL`
 
 ## Example connection URLs

--- a/components/SQLEditor.go
+++ b/components/SQLEditor.go
@@ -126,7 +126,9 @@ func openExternalEditor(s *SQLEditor) string {
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 
+	// ----
 	// cmd.Stderr = os.Stderr
+	// ----
 
 	err = cmd.Run()
 	if err != nil {
@@ -155,7 +157,7 @@ func getEditor() string {
 	}
 
 	if editor == "" {
-		editor = "vi" 		// use "vi" if $EDITOR not set
+		editor = "vi" 			// use "vi" if $EDITOR not set
 	}
 
 	return editor
@@ -169,16 +171,16 @@ func getTerminal() string {
 		terminal = os.Getenv("TERMINAL")
 	}
 	
-	// Check if x-terminal-emulator exists.
-	x_term_emu, err := exec.LookPath("x-terminal-emulator")
+	if terminal == "" {
+		terminal = "xterm"
+	}
+
+	// Check if x-terminal-emulator exists
+	terminalEmulator, err := exec.LookPath("x-terminal-emulator")
 
 	// If exists then set terminal as x-terminal-emulator
 	if err == nil {
-		terminal = x_term_emu
-	}
-
-	if terminal == "" {
-		terminal = "xterm"			// use "xterm" if none of the above exists
+		terminal = terminalEmulator			// overload `terminal` if terminalEmulator exists
 	}
 
 	return terminal


### PR DESCRIPTION
>  Added support for external editors while in SQL editor.

>  Users can set $SQL_EDITOR for specific editor.


>  Opens another terminal for external editor.

> Users can set $SQL_TERMINAL for specific editor.


> Added keybindings for external editor in README.

> Creates temporary file (lazysql.sql) in current working directory.

> Currently, this feature is supported only for linux.