### PR TITLE
Postgres connections fix

### DIFF
--- a/components/Home.go
+++ b/components/Home.go
@@ -90,9 +90,13 @@ func (home *Home) subscribeToTreeChanges() {
 				home.TabbedPane.AppendTab(tableName, table)
 			}
 
-			table.FetchRecords()
+			table.FetchRecords(func() {
+				home.focusLeftWrapper()
+			})
 
-			home.focusRightWrapper()
+			if table.state.error == "" {
+				home.focusRightWrapper()
+			}
 
 			app.App.ForceDraw()
 		}
@@ -202,7 +206,7 @@ func (home *Home) rightWrapperInputCapture(event *tcell.EventKey) *tcell.EventKe
 
 			if ((table.Menu != nil && table.Menu.GetSelectedOption() == 1) || table.Menu == nil) && !table.Pagination.GetIsFirstPage() && !table.GetIsLoading() {
 				table.Pagination.SetOffset(table.Pagination.GetOffset() - table.Pagination.GetLimit())
-				table.FetchRecords()
+				table.FetchRecords(nil)
 
 			}
 
@@ -216,7 +220,7 @@ func (home *Home) rightWrapperInputCapture(event *tcell.EventKey) *tcell.EventKe
 
 			if ((table.Menu != nil && table.Menu.GetSelectedOption() == 1) || table.Menu == nil) && !table.Pagination.GetIsLastPage() && !table.GetIsLoading() {
 				table.Pagination.SetOffset(table.Pagination.GetOffset() + table.Pagination.GetLimit())
-				table.FetchRecords()
+				table.FetchRecords(nil)
 			}
 		}
 	}
@@ -287,7 +291,7 @@ func (home *Home) homeInputCapture(event *tcell.EventKey) *tcell.EventKey {
 						home.ListOfDbChanges = []models.DbDmlChange{}
 						home.ListOfDbInserts = []models.DbInsert{}
 
-						table.FetchRecords()
+						table.FetchRecords(nil)
 						home.Tree.ForceRemoveHighlight()
 
 					}

--- a/components/ResultsTable.go
+++ b/components/ResultsTable.go
@@ -572,7 +572,7 @@ func (table *ResultsTable) subscribeToFilterChanges() {
 		switch stateChange.Key {
 		case "Filter":
 			if stateChange.Value != "" {
-				rows := table.FetchRecords()
+				rows := table.FetchRecords(nil)
 
 				if len(rows) > 1 {
 					table.Menu.SetSelectedOption(1)
@@ -591,7 +591,7 @@ func (table *ResultsTable) subscribeToFilterChanges() {
 				}
 
 			} else {
-				table.FetchRecords()
+				table.FetchRecords(nil)
 
 				table.SetInputCapture(table.tableInputCapture)
 				App.SetFocus(table)
@@ -863,7 +863,7 @@ func (table *ResultsTable) SetSortedBy(column string, direction string) {
 	}
 }
 
-func (table *ResultsTable) FetchRecords() [][]string {
+func (table *ResultsTable) FetchRecords(onError func()) [][]string {
 	tableName := table.GetDBReference()
 
 	table.SetLoading(true)
@@ -877,7 +877,7 @@ func (table *ResultsTable) FetchRecords() [][]string {
 	records, totalRecords, err := table.DBDriver.GetRecords(tableName, where, sort, table.Pagination.GetOffset(), table.Pagination.GetLimit())
 
 	if err != nil {
-		table.SetError(err.Error(), nil)
+		table.SetError(err.Error(), onError)
 		table.SetLoading(false)
 	} else {
 		if table.GetIsFiltering() {

--- a/drivers/postgres.go
+++ b/drivers/postgres.go
@@ -324,14 +324,20 @@ func (db *Postgres) GetRecords(table, where, sort string, offset, limit int) (re
 		defaultLimit = limit
 	}
 
-	query := fmt.Sprintf("SELECT * FROM %s s LIMIT %d OFFSET %d", table, defaultLimit, offset)
+	splittedTableName := strings.Split(table, ".")
+	schema := splittedTableName[0]
+	tableName := splittedTableName[1]
+
+	formattedTableName := fmt.Sprintf("\"%s\".\"%s\"", schema, tableName)
+
+	query := fmt.Sprintf("SELECT * FROM %s s LIMIT %d OFFSET %d", formattedTableName, defaultLimit, offset)
 
 	if where != "" {
-		query = fmt.Sprintf("SELECT * FROM %s %s LIMIT %d OFFSET %d", table, where, defaultLimit, offset)
+		query = fmt.Sprintf("SELECT * FROM %s %s LIMIT %d OFFSET %d", formattedTableName, where, defaultLimit, offset)
 	}
 
 	if sort != "" {
-		query = fmt.Sprintf("SELECT * FROM %s %s ORDER BY %s LIMIT %d OFFSET %d", table, where, sort, defaultLimit, offset)
+		query = fmt.Sprintf("SELECT * FROM %s %s ORDER BY %s LIMIT %d OFFSET %d", formattedTableName, where, sort, defaultLimit, offset)
 	}
 
 	paginatedRows, err := db.Connection.Query(query)
@@ -340,7 +346,7 @@ func (db *Postgres) GetRecords(table, where, sort string, offset, limit int) (re
 	}
 
 	if isPaginationEnabled {
-		queryWithoutLimit := fmt.Sprintf("SELECT COUNT(*) FROM %s %s", table, where)
+		queryWithoutLimit := fmt.Sprintf("SELECT COUNT(*) FROM %s %s", formattedTableName, where)
 
 		rows := db.Connection.QueryRow(queryWithoutLimit)
 


### PR DESCRIPTION
Fixes not being able to connect to other databases than the default one (postgres) using the Tree when connecting to an instance using a connection string without database name at the end.

Also, Fixes #64.