### PR TITLE
golangci lint

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,11 @@ jobs:
       -
         name: Set up Go
         uses: actions/setup-go@v5
+
+      -
+        name: Golangci-lint
+        uses: golangci/golangci-lint-action@v6.0.1
+
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,28 @@
+---
+# golangci-lint configuration file made by @ccoVeille
+# Source: https://github.com/ccoVeille/golangci-lint-config-examples/
+# Author: @ccoVeille
+# License: MIT
+# Variant: 01-defaults
+# Version: v1.0.0
+#
+linters:
+  # some linters are enabled by default
+  # https://golangci-lint.run/usage/linters/
+  #
+  # enable some extra linters
+  enable:
+    # Errcheck is a program for checking for unchecked errors in Go code.
+    - errcheck
+
+    # Linter for Go source code that specializes in simplifying code.
+    - gosimple
+
+    # Vet examines Go source code and reports suspicious constructs.
+    - govet
+
+    # Detects when assignments to existing variables are not used.
+    - ineffassign
+
+    # It's a set of rules from staticcheck. See https://staticcheck.io/
+    - staticcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,7 @@
 # Source: https://github.com/ccoVeille/golangci-lint-config-examples/
 # Author: @ccoVeille
 # License: MIT
-# Variant: 01-defaults
+# Variant: 03-safe
 # Version: v1.0.0
 #
 linters:
@@ -26,3 +26,131 @@ linters:
 
     # It's a set of rules from staticcheck. See https://staticcheck.io/
     - staticcheck
+
+    # Fast, configurable, extensible, flexible, and beautiful linter for Go.
+    # Drop-in replacement of golint.
+    - revive
+
+    # check imports order and makes it always deterministic.
+    - gci
+
+    # make sure to use t.Helper() when needed
+    - thelper
+
+    # mirror suggests rewrites to avoid unnecessary []byte/string conversion
+    - mirror
+
+    # detect the possibility to use variables/constants from the Go standard library.
+    - usestdlibvars
+
+    # Finds commonly misspelled English words.
+    - misspell
+
+    # Checks for duplicate words in the source code.
+    - dupword
+
+linters-settings:
+  gci:  # define the section orders for imports
+    sections:
+      # Standard section: captures all standard packages.
+      - standard
+      # Default section: catchall that is not standard or custom
+      - default
+      # linters that related to local tool, so they should be separated
+      - localmodule
+
+  revive:
+    rules:
+      # these are the default revive rules
+      # you can remove the whole "rules" node if you want
+      # BUT
+      # ! /!\ they all need to be present when you want to add more rules than the default ones
+      # otherwise, you won't have the default rules, but only the ones you define in the "rules" node
+
+      # Blank import should be only in a main or test package, or have a comment justifying it.
+      - name: blank-imports
+
+      # context.Context() should be the first parameter of a function when provided as argument.
+      - name: context-as-argument
+        arguments:
+          - allowTypesBefore: "*testing.T"
+
+      # Basic types should not be used as a key in `context.WithValue`
+      - name: context-keys-type
+
+      # Importing with `.` makes the programs much harder to understand
+      - name: dot-imports
+
+      # Empty blocks make code less readable and could be a symptom of a bug or unfinished refactoring.
+      - name: empty-block
+
+      # for better readability, variables of type `error` must be named with the prefix `err`.
+      - name: error-naming
+
+      # for better readability, the errors should be last in the list of returned values by a function.
+      - name: error-return
+
+      # for better readability, error messages should not be capitalized or end with punctuation or a newline.
+      - name: error-strings
+
+      # report when replacing `errors.New(fmt.Sprintf())` with `fmt.Errorf()` is possible
+      - name: errorf
+
+      # incrementing an integer variable by 1 is recommended to be done using the `++` operator
+      - name: increment-decrement
+
+      # highlights redundant else-blocks that can be eliminated from the code
+      - name: indent-error-flow
+
+      # This rule suggests a shorter way of writing ranges that do not use the second value.
+      - name: range
+
+      # receiver names in a method should reflect the struct name (p for Person, for example)
+      - name: receiver-naming
+
+      # redefining built in names (true, false, append, make) can lead to bugs very difficult to detect.
+      - name: redefines-builtin-id
+
+      # redundant else-blocks that can be eliminated from the code.
+      - name: superfluous-else
+
+      # prevent confusing name for variables when using `time` package
+      - name: time-naming
+
+      # warns when an exported function or method returns a value of an un-exported type.
+      - name: unexported-return
+
+      # spots and proposes to remove unreachable code. also helps to spot errors
+      - name: unreachable-code
+
+      # Functions or methods with unused parameters can be a symptom of an unfinished refactoring or a bug.
+      - name: unused-parameter
+
+      # report when a variable declaration can be simplified
+      - name: var-declaration
+
+      # warns when initialism, variable or package naming conventions are not followed.
+      - name: var-naming
+
+  dupword:
+    # Keywords used to ignore detection.
+    # Default: []
+    ignore:
+    #  - "blah" # this will accept "blah blah …" as a valid duplicate word
+
+  misspell:
+    # Correct spellings using locale preferences for US or UK.
+    # Setting locale to US will correct the British spelling of 'colour' to 'color'.
+    # Default ("") is to use a neutral variety of English.
+    locale: US
+
+    # List of words to ignore
+    # among the one defined in https://github.com/golangci/misspell/blob/master/words.go
+    ignore-words:
+    #  - valor
+    #  - and
+
+    # Extra word corrections.
+    extra-words:
+    #  - typo: "whattever"
+    #    correction: "whatever"

--- a/app/Keymap.go
+++ b/app/Keymap.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"github.com/gdamore/tcell/v2"
+
 	. "github.com/jorgerojas26/lazysql/commands"
 	. "github.com/jorgerojas26/lazysql/keymap"
 )

--- a/app/Keymap.go
+++ b/app/Keymap.go
@@ -3,8 +3,15 @@ package app
 import (
 	"github.com/gdamore/tcell/v2"
 
-	. "github.com/jorgerojas26/lazysql/commands"
-	. "github.com/jorgerojas26/lazysql/keymap"
+	cmd "github.com/jorgerojas26/lazysql/commands"
+	"github.com/jorgerojas26/lazysql/keymap"
+)
+
+// local alias added for clarity purpose
+type (
+	Bind = keymap.Bind
+	Key  = keymap.Key
+	Map  = keymap.Map
 )
 
 // KeymapSystem is the actual key mapping system.
@@ -32,54 +39,54 @@ func (c KeymapSystem) Group(name string) Map {
 
 // Resolve translates a tcell.EventKey into a command based on the mappings in
 // the global group
-func (c KeymapSystem) Resolve(event *tcell.EventKey) Command {
+func (c KeymapSystem) Resolve(event *tcell.EventKey) cmd.Command {
 	return c.Global.Resolve(event)
 }
 
 // Define a global KeymapSystem object with default keybinds
-var Keymaps KeymapSystem = KeymapSystem{
+var Keymaps = KeymapSystem{
 	Global: Map{
-		Bind{Key: Key{Char: 'L'}, Cmd: MoveRight},
-		Bind{Key: Key{Char: 'H'}, Cmd: MoveLeft},
-		Bind{Key: Key{Code: tcell.KeyCtrlE}, Cmd: SwitchToEditorView},
-		Bind{Key: Key{Code: tcell.KeyCtrlS}, Cmd: Save},
-		Bind{Key: Key{Char: 'q'}, Cmd: Quit},
-		Bind{Key: Key{Code: tcell.KeyBackspace2}, Cmd: SwitchToConnectionsView},
+		Bind{Key: Key{Char: 'L'}, Cmd: cmd.MoveRight},
+		Bind{Key: Key{Char: 'H'}, Cmd: cmd.MoveLeft},
+		Bind{Key: Key{Code: tcell.KeyCtrlE}, Cmd: cmd.SwitchToEditorView},
+		Bind{Key: Key{Code: tcell.KeyCtrlS}, Cmd: cmd.Save},
+		Bind{Key: Key{Char: 'q'}, Cmd: cmd.Quit},
+		Bind{Key: Key{Code: tcell.KeyBackspace2}, Cmd: cmd.SwitchToConnectionsView},
 	},
 	Groups: map[string]Map{
 		"tree": {
-			Bind{Key: Key{Char: 'g'}, Cmd: GotoTop},
-			Bind{Key: Key{Char: 'G'}, Cmd: GotoBottom},
-			Bind{Key: Key{Code: tcell.KeyEnter}, Cmd: Execute},
-			Bind{Key: Key{Char: 'j'}, Cmd: MoveDown},
-			Bind{Key: Key{Code: tcell.KeyDown}, Cmd: MoveDown},
-			Bind{Key: Key{Char: 'k'}, Cmd: MoveUp},
-			Bind{Key: Key{Code: tcell.KeyUp}, Cmd: MoveUp},
+			Bind{Key: Key{Char: 'g'}, Cmd: cmd.GotoTop},
+			Bind{Key: Key{Char: 'G'}, Cmd: cmd.GotoBottom},
+			Bind{Key: Key{Code: tcell.KeyEnter}, Cmd: cmd.Execute},
+			Bind{Key: Key{Char: 'j'}, Cmd: cmd.MoveDown},
+			Bind{Key: Key{Code: tcell.KeyDown}, Cmd: cmd.MoveDown},
+			Bind{Key: Key{Char: 'k'}, Cmd: cmd.MoveUp},
+			Bind{Key: Key{Code: tcell.KeyUp}, Cmd: cmd.MoveUp},
 		},
 		"table": {
-			Bind{Key: Key{Char: '/'}, Cmd: Search},
-			Bind{Key: Key{Char: 'c'}, Cmd: Edit},
-			Bind{Key: Key{Char: 'd'}, Cmd: Delete},
-			Bind{Key: Key{Char: 'w'}, Cmd: GotoNext},
-			Bind{Key: Key{Char: 'b'}, Cmd: GotoPrev},
-			Bind{Key: Key{Char: '$'}, Cmd: GotoEnd},
-			Bind{Key: Key{Char: '0'}, Cmd: GotoStart},
-			Bind{Key: Key{Char: 'y'}, Cmd: Copy},
-			Bind{Key: Key{Char: 'o'}, Cmd: AppendNewRow},
+			Bind{Key: Key{Char: '/'}, Cmd: cmd.Search},
+			Bind{Key: Key{Char: 'c'}, Cmd: cmd.Edit},
+			Bind{Key: Key{Char: 'd'}, Cmd: cmd.Delete},
+			Bind{Key: Key{Char: 'w'}, Cmd: cmd.GotoNext},
+			Bind{Key: Key{Char: 'b'}, Cmd: cmd.GotoPrev},
+			Bind{Key: Key{Char: '$'}, Cmd: cmd.GotoEnd},
+			Bind{Key: Key{Char: '0'}, Cmd: cmd.GotoStart},
+			Bind{Key: Key{Char: 'y'}, Cmd: cmd.Copy},
+			Bind{Key: Key{Char: 'o'}, Cmd: cmd.AppendNewRow},
 			// Tabs
-			Bind{Key: Key{Char: '['}, Cmd: TabPrev},
-			Bind{Key: Key{Char: ']'}, Cmd: TabNext},
-			Bind{Key: Key{Char: '{'}, Cmd: TabFirst},
-			Bind{Key: Key{Char: '}'}, Cmd: TabLast},
-			Bind{Key: Key{Char: 'X'}, Cmd: TabClose},
+			Bind{Key: Key{Char: '['}, Cmd: cmd.TabPrev},
+			Bind{Key: Key{Char: ']'}, Cmd: cmd.TabNext},
+			Bind{Key: Key{Char: '{'}, Cmd: cmd.TabFirst},
+			Bind{Key: Key{Char: '}'}, Cmd: cmd.TabLast},
+			Bind{Key: Key{Char: 'X'}, Cmd: cmd.TabClose},
 			// Pages
-			Bind{Key: Key{Char: '>'}, Cmd: PageNext},
-			Bind{Key: Key{Char: '<'}, Cmd: PagePrev},
+			Bind{Key: Key{Char: '>'}, Cmd: cmd.PageNext},
+			Bind{Key: Key{Char: '<'}, Cmd: cmd.PagePrev},
 		},
 		"editor": {
-			Bind{Key: Key{Code: tcell.KeyCtrlR}, Cmd: Execute},
-			Bind{Key: Key{Code: tcell.KeyEscape}, Cmd: Quit},
-			Bind{Key: Key{Code: tcell.KeyCtrlSpace}, Cmd: OpenInExternalEditor},
+			Bind{Key: Key{Code: tcell.KeyCtrlR}, Cmd: cmd.Execute},
+			Bind{Key: Key{Code: tcell.KeyEscape}, Cmd: cmd.Quit},
+			Bind{Key: Key{Code: tcell.KeyCtrlSpace}, Cmd: cmd.OpenInExternalEditor},
 		},
 	},
 }

--- a/components/ConnectionForm.go
+++ b/components/ConnectionForm.go
@@ -85,67 +85,67 @@ func (form *ConnectionForm) inputCapture(connectionPages *models.ConnectionPages
 			if err != nil {
 				form.StatusText.SetText(err.Error()).SetTextStyle(tcell.StyleDefault.Foreground(tcell.ColorRed))
 				return event
-			} else {
-
-				databases, _ := helpers.LoadConnections()
-				newDatabases := make([]models.Connection, len(databases))
-
-				DBName := strings.Split(parsed.Normalize(",", "NULL", 0), ",")[3]
-
-				if DBName == "NULL" {
-					DBName = ""
-				}
-
-				parsedDatabaseData := models.Connection{
-					Name:     connectionName,
-					Provider: parsed.Driver,
-					DBName:   DBName,
-					URL:      connectionString,
-				}
-
-				switch form.Action {
-				case "create":
-
-					newDatabases = append(databases, parsedDatabaseData)
-					err := helpers.SaveConnectionConfig(newDatabases)
-					if err != nil {
-						form.StatusText.SetText(err.Error()).SetTextStyle(tcell.StyleDefault.Foreground(tcell.ColorRed))
-						return event
-					}
-
-				case "edit":
-					newDatabases = make([]models.Connection, len(databases))
-					row, _ := ConnectionListTable.GetSelection()
-
-					for i, database := range databases {
-						if i == row {
-							newDatabases[i] = parsedDatabaseData
-
-							// newDatabases[i].Name = connectionName
-							// newDatabases[i].Provider = database.Provider
-							// newDatabases[i].User = parsed.User.Username()
-							// newDatabases[i].Password, _ = parsed.User.Password()
-							// newDatabases[i].Host = parsed.Hostname()
-							// newDatabases[i].Port = parsed.Port()
-							// newDatabases[i].Query = parsed.Query().Encode()
-							// newDatabases[i].DBName = helpers.ParsedDBName(parsed.Path)
-							// newDatabases[i].DSN = parsed.DSN
-						} else {
-							newDatabases[i] = database
-						}
-					}
-
-					err := helpers.SaveConnectionConfig(newDatabases)
-					if err != nil {
-						form.StatusText.SetText(err.Error()).SetTextStyle(tcell.StyleDefault.Foreground(tcell.ColorRed))
-						return event
-
-					}
-				}
-
-				ConnectionListTable.SetConnections(newDatabases)
-				connectionPages.SwitchToPage("Connections")
 			}
+
+			databases, _ := helpers.LoadConnections()
+			newDatabases := make([]models.Connection, len(databases))
+
+			DBName := strings.Split(parsed.Normalize(",", "NULL", 0), ",")[3]
+
+			if DBName == "NULL" {
+				DBName = ""
+			}
+
+			parsedDatabaseData := models.Connection{
+				Name:     connectionName,
+				Provider: parsed.Driver,
+				DBName:   DBName,
+				URL:      connectionString,
+			}
+
+			switch form.Action {
+			case "create":
+
+				newDatabases = append(databases, parsedDatabaseData)
+				err := helpers.SaveConnectionConfig(newDatabases)
+				if err != nil {
+					form.StatusText.SetText(err.Error()).SetTextStyle(tcell.StyleDefault.Foreground(tcell.ColorRed))
+					return event
+				}
+
+			case "edit":
+				newDatabases = make([]models.Connection, len(databases))
+				row, _ := ConnectionListTable.GetSelection()
+
+				for i, database := range databases {
+					if i == row {
+						newDatabases[i] = parsedDatabaseData
+
+						// newDatabases[i].Name = connectionName
+						// newDatabases[i].Provider = database.Provider
+						// newDatabases[i].User = parsed.User.Username()
+						// newDatabases[i].Password, _ = parsed.User.Password()
+						// newDatabases[i].Host = parsed.Hostname()
+						// newDatabases[i].Port = parsed.Port()
+						// newDatabases[i].Query = parsed.Query().Encode()
+						// newDatabases[i].DBName = helpers.ParsedDBName(parsed.Path)
+						// newDatabases[i].DSN = parsed.DSN
+					} else {
+						newDatabases[i] = database
+					}
+				}
+
+				err := helpers.SaveConnectionConfig(newDatabases)
+				if err != nil {
+					form.StatusText.SetText(err.Error()).SetTextStyle(tcell.StyleDefault.Foreground(tcell.ColorRed))
+					return event
+
+				}
+			}
+
+			ConnectionListTable.SetConnections(newDatabases)
+			connectionPages.SwitchToPage("Connections")
+
 		} else if event.Key() == tcell.KeyF2 {
 			connectionString := form.GetFormItem(1).(*tview.InputField).GetText()
 			go form.testConnection(connectionString)

--- a/components/ConnectionForm.go
+++ b/components/ConnectionForm.go
@@ -3,12 +3,12 @@ package components
 import (
 	"strings"
 
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+
 	"github.com/jorgerojas26/lazysql/drivers"
 	"github.com/jorgerojas26/lazysql/helpers"
 	"github.com/jorgerojas26/lazysql/models"
-
-	"github.com/gdamore/tcell/v2"
-	"github.com/rivo/tview"
 )
 
 type ConnectionForm struct {

--- a/components/ConnectionPage.go
+++ b/components/ConnectionPage.go
@@ -1,9 +1,9 @@
 package components
 
 import (
-	"github.com/jorgerojas26/lazysql/models"
-
 	"github.com/rivo/tview"
+
+	"github.com/jorgerojas26/lazysql/models"
 )
 
 func NewConnectionPages() *models.ConnectionPages {

--- a/components/ConnectionSelection.go
+++ b/components/ConnectionSelection.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+
 	"github.com/jorgerojas26/lazysql/app"
 	"github.com/jorgerojas26/lazysql/drivers"
 	"github.com/jorgerojas26/lazysql/helpers"
 	"github.com/jorgerojas26/lazysql/models"
-
-	"github.com/gdamore/tcell/v2"
-	"github.com/rivo/tview"
 )
 
 type ConnectionSelection struct {

--- a/components/ConnectionsTable.go
+++ b/components/ConnectionsTable.go
@@ -1,11 +1,11 @@
 package components
 
 import (
-	"github.com/jorgerojas26/lazysql/helpers"
-	"github.com/jorgerojas26/lazysql/models"
-
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
+
+	"github.com/jorgerojas26/lazysql/helpers"
+	"github.com/jorgerojas26/lazysql/models"
 )
 
 type ConnectionsTable struct {

--- a/components/Home.go
+++ b/components/Home.go
@@ -77,7 +77,7 @@ func (home *Home) subscribeToTreeChanges() {
 			tableName := stateChange.Value.(string)
 
 			tab := home.TabbedPane.GetTabByName(tableName)
-			var table *ResultsTable = nil
+			var table *ResultsTable
 
 			if tab != nil {
 				table = tab.Content
@@ -230,7 +230,7 @@ func (home *Home) rightWrapperInputCapture(event *tcell.EventKey) *tcell.EventKe
 func (home *Home) homeInputCapture(event *tcell.EventKey) *tcell.EventKey {
 	tab := home.TabbedPane.GetCurrentTab()
 
-	var table *ResultsTable = nil
+	var table *ResultsTable
 
 	if tab != nil {
 		table = tab.Content

--- a/components/Home.go
+++ b/components/Home.go
@@ -1,14 +1,13 @@
 package components
 
 import (
-	"github.com/jorgerojas26/lazysql/commands"
-	"github.com/jorgerojas26/lazysql/models"
-
-	"github.com/jorgerojas26/lazysql/app"
-	"github.com/jorgerojas26/lazysql/drivers"
-
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
+
+	"github.com/jorgerojas26/lazysql/app"
+	"github.com/jorgerojas26/lazysql/commands"
+	"github.com/jorgerojas26/lazysql/drivers"
+	"github.com/jorgerojas26/lazysql/models"
 )
 
 type Home struct {

--- a/components/ResultTableFilter.go
+++ b/components/ResultTableFilter.go
@@ -1,10 +1,10 @@
 package components
 
 import (
-	"github.com/jorgerojas26/lazysql/models"
-
 	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
+
+	"github.com/jorgerojas26/lazysql/models"
 )
 
 type ResultsTableFilter struct {

--- a/components/ResultsTable.go
+++ b/components/ResultsTable.go
@@ -4,16 +4,15 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/jorgerojas26/lazysql/app"
-	"github.com/jorgerojas26/lazysql/commands"
-	"github.com/jorgerojas26/lazysql/models"
-
-	"github.com/jorgerojas26/lazysql/drivers"
-
 	"github.com/gdamore/tcell/v2"
 	"github.com/google/uuid"
 	"github.com/rivo/tview"
 	"golang.design/x/clipboard"
+
+	"github.com/jorgerojas26/lazysql/app"
+	"github.com/jorgerojas26/lazysql/commands"
+	"github.com/jorgerojas26/lazysql/drivers"
+	"github.com/jorgerojas26/lazysql/models"
 )
 
 type ResultsTableState struct {

--- a/components/ResultsTable.go
+++ b/components/ResultsTable.go
@@ -437,13 +437,13 @@ func (table *ResultsTable) tableInputCapture(event *tcell.EventKey) *tcell.Event
 
 			newRow := make([]string, table.GetColumnCount())
 			newRowIndex := table.GetRowCount()
-			newRowUuid := uuid.New()
+			newRowUUID := uuid.New()
 
 			for i := 0; i < table.GetColumnCount(); i++ {
 				newRow[i] = "Default"
 			}
 
-			table.InsertRow(newRow, newRowIndex, newRowUuid)
+			table.InsertRow(newRow, newRowIndex, newRowUUID)
 
 			for i := 0; i < table.GetColumnCount(); i++ {
 				table.GetCell(newRowIndex, i).SetBackgroundColor(tcell.ColorDarkGreen)
@@ -453,7 +453,7 @@ func (table *ResultsTable) tableInputCapture(event *tcell.EventKey) *tcell.Event
 				Table:           table.GetDBReference(),
 				Columns:         table.GetRecords()[0],
 				Values:          newRow,
-				PrimaryKeyValue: newRowUuid,
+				PrimaryKeyValue: newRowUUID,
 				Option:          1,
 			}
 
@@ -970,9 +970,9 @@ func (table *ResultsTable) StartEditingCell(row int, col int, callback func(newV
 	App.SetFocus(inputField)
 }
 
-func (table *ResultsTable) CheckIfRowIsInserted(rowId uuid.UUID) bool {
+func (table *ResultsTable) CheckIfRowIsInserted(rowID uuid.UUID) bool {
 	for _, insertedRow := range *table.state.listOfDbInserts {
-		if insertedRow.PrimaryKeyValue == rowId {
+		if insertedRow.PrimaryKeyValue == rowID {
 			return true
 		}
 	}
@@ -980,9 +980,9 @@ func (table *ResultsTable) CheckIfRowIsInserted(rowId uuid.UUID) bool {
 	return false
 }
 
-func (table *ResultsTable) MutateInsertedRowCell(rowId uuid.UUID, colIndex int, newValue string) {
+func (table *ResultsTable) MutateInsertedRowCell(rowID uuid.UUID, colIndex int, newValue string) {
 	for i, insertedRow := range *table.state.listOfDbInserts {
-		if insertedRow.PrimaryKeyValue == rowId {
+		if insertedRow.PrimaryKeyValue == rowID {
 			(*table.state.listOfDbInserts)[i].Values[colIndex] = newValue
 		}
 	}

--- a/components/SQLEditor.go
+++ b/components/SQLEditor.go
@@ -146,7 +146,7 @@ func openExternalEditor(s *SQLEditor) string {
 
 // Function to select editor
 func getEditor() string {
-	var editor string = os.Getenv("SQL_EDITOR")
+	editor := os.Getenv("SQL_EDITOR")
 	if editor == "" {
 		editor = os.Getenv("EDITOR")
 	}
@@ -164,7 +164,7 @@ func getEditor() string {
 
 // Function to select terminal
 func getTerminal() string {
-	var terminal string = os.Getenv("SQL_TERMINAL")
+	terminal := os.Getenv("SQL_TERMINAL")
 
 	if terminal == "" {
 		terminal = os.Getenv("TERMINAL")

--- a/components/Tree.go
+++ b/components/Tree.go
@@ -3,13 +3,13 @@ package components
 import (
 	"fmt"
 
+	"github.com/gdamore/tcell/v2"
+	"github.com/rivo/tview"
+
 	"github.com/jorgerojas26/lazysql/app"
 	"github.com/jorgerojas26/lazysql/commands"
 	"github.com/jorgerojas26/lazysql/drivers"
 	"github.com/jorgerojas26/lazysql/models"
-
-	"github.com/gdamore/tcell/v2"
-	"github.com/rivo/tview"
 )
 
 type TreeState struct {

--- a/drivers/mysql.go
+++ b/drivers/mysql.go
@@ -7,10 +7,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/jorgerojas26/lazysql/models"
-
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/xo/dburl"
+
+	"github.com/jorgerojas26/lazysql/models"
 )
 
 type MySQL struct {

--- a/drivers/mysql.go
+++ b/drivers/mysql.go
@@ -337,14 +337,14 @@ func (db *MySQL) DeleteRecord(table, primaryKeyColumnName, primaryKeyValue strin
 }
 
 func (db *MySQL) ExecuteDMLStatement(query string) (result string, err error) {
-	res, error := db.Connection.Exec(query)
+	res, err := db.Connection.Exec(query)
 
-	if error != nil {
-		return result, error
+	if err != nil {
+		return result, err
 	} else {
 		rowsAffected, _ := res.RowsAffected()
 
-		return fmt.Sprintf("%d rows affected", rowsAffected), error
+		return fmt.Sprintf("%d rows affected", rowsAffected), err
 	}
 }
 
@@ -405,9 +405,9 @@ func (db *MySQL) ExecutePendingChanges(changes []models.DbDmlChange, inserts []m
 		values := make([]string, 0, len(insert.Values))
 
 		for _, value := range insert.Values {
-			_, error := strconv.ParseFloat(value, 64)
+			_, err := strconv.ParseFloat(value, 64)
 
-			if strings.ToLower(value) != "default" && error != nil {
+			if strings.ToLower(value) != "default" && err != nil {
 				values = append(values, fmt.Sprintf("\"%s\"", value))
 			} else {
 				values = append(values, value)
@@ -419,9 +419,9 @@ func (db *MySQL) ExecutePendingChanges(changes []models.DbDmlChange, inserts []m
 		queries = append(queries, query)
 	}
 
-	tx, error := db.Connection.Begin()
-	if error != nil {
-		return error
+	tx, err := db.Connection.Begin()
+	if err != nil {
+		return err
 	}
 
 	for _, query := range queries {

--- a/drivers/mysql.go
+++ b/drivers/mysql.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	_ "github.com/go-sql-driver/mysql"
 	"github.com/xo/dburl"
 
 	"github.com/jorgerojas26/lazysql/models"

--- a/drivers/mysql.go
+++ b/drivers/mysql.go
@@ -84,7 +84,7 @@ func (db *MySQL) GetTables(database string) (map[string][]string, error) {
 func (db *MySQL) GetTableColumns(database, table string) (results [][]string, err error) {
 	table = db.formatTableName(table)
 
-	rows, err := db.Connection.Query("DESCRIBE " + table)
+	rows, err := db.Connection.Query(fmt.Sprintf("DESCRIBE %s.%s", database, table))
 	if err != nil {
 		return nil, err
 	}

--- a/drivers/mysql.go
+++ b/drivers/mysql.go
@@ -213,7 +213,10 @@ func (db *MySQL) GetIndexes(table string) (results [][]string, err error) {
 	}
 	defer rows.Close()
 
-	columns, _ := rows.Columns()
+	columns, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
 
 	results = append(results, columns)
 
@@ -281,7 +284,10 @@ func (db *MySQL) GetRecords(table, where, sort string, offset, limit int) (pagin
 		defer paginatedRows.Close()
 	}
 
-	columns, _ := paginatedRows.Columns()
+	columns, err := paginatedRows.Columns()
+	if err != nil {
+		return nil, 0, err
+	}
 
 	paginatedResults = append(paginatedResults, columns)
 
@@ -316,7 +322,10 @@ func (db *MySQL) ExecuteQuery(query string) (results [][]string, err error) {
 
 	defer rows.Close()
 
-	columns, _ := rows.Columns()
+	columns, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
 
 	results = append(results, columns)
 
@@ -363,14 +372,16 @@ func (db *MySQL) DeleteRecord(table, primaryKeyColumnName, primaryKeyValue strin
 
 func (db *MySQL) ExecuteDMLStatement(query string) (result string, err error) {
 	res, err := db.Connection.Exec(query)
-
 	if err != nil {
-		return result, err
-	} else {
-		rowsAffected, _ := res.RowsAffected()
-
-		return fmt.Sprintf("%d rows affected", rowsAffected), err
+		return "", err
 	}
+
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%d rows affected", rowsAffected), nil
 }
 
 func (db *MySQL) ExecutePendingChanges(changes []models.DbDmlChange, inserts []models.DbInsert) (err error) {

--- a/drivers/mysql.go
+++ b/drivers/mysql.go
@@ -42,14 +42,14 @@ func (db *MySQL) GetDatabases() ([]string, error) {
 
 	rows, err := db.Connection.Query("SHOW DATABASES")
 	if err != nil {
-		return databases, err
+		return nil, err
 	}
 
 	for rows.Next() {
 		var database string
 		err := rows.Scan(&database)
 		if err != nil {
-			return databases, err
+			return nil, err
 		}
 		if database != "information_schema" && database != "mysql" && database != "performance_schema" && database != "sys" {
 			databases = append(databases, database)
@@ -65,7 +65,7 @@ func (db *MySQL) GetTables(database string) (map[string][]string, error) {
 	tables := make(map[string][]string)
 
 	if err != nil {
-		return tables, err
+		return nil, err
 	}
 
 	for rows.Next() {
@@ -83,13 +83,13 @@ func (db *MySQL) GetTableColumns(database, table string) (results [][]string, er
 
 	rows, err := db.Connection.Query("DESCRIBE " + table)
 	if err != nil {
-		return results, err
+		return nil, err
 	}
 	defer rows.Close()
 
 	columns, err := rows.Columns()
 	if err != nil {
-		return results, err
+		return nil, err
 	}
 
 	results = append(results, columns)
@@ -122,14 +122,14 @@ func (db *MySQL) GetConstraints(table string) (results [][]string, err error) {
 
 	rows, err := db.Connection.Query(fmt.Sprintf("SELECT CONSTRAINT_NAME, COLUMN_NAME, REFERENCED_TABLE_NAME, REFERENCED_COLUMN_NAME FROM information_schema.KEY_COLUMN_USAGE where TABLE_SCHEMA = '%s' AND TABLE_NAME = '%s'", database, tableName))
 	if err != nil {
-		return results, err
+		return nil, err
 	}
 
 	defer rows.Close()
 
 	columns, err := rows.Columns()
 	if err != nil {
-		return results, err
+		return nil, err
 	}
 
 	results = append(results, columns)
@@ -161,14 +161,14 @@ func (db *MySQL) GetForeignKeys(table string) (results [][]string, err error) {
 
 	rows, err := db.Connection.Query(fmt.Sprintf("SELECT TABLE_NAME, COLUMN_NAME, CONSTRAINT_NAME, REFERENCED_COLUMN_NAME, REFERENCED_TABLE_NAME FROM information_schema.KEY_COLUMN_USAGE where REFERENCED_TABLE_SCHEMA = '%s' AND REFERENCED_TABLE_NAME = '%s'", database, tableName))
 	if err != nil {
-		return results, err
+		return nil, err
 	}
 
 	defer rows.Close()
 
 	columns, err := rows.Columns()
 	if err != nil {
-		return results, err
+		return nil, err
 	}
 
 	results = append(results, columns)
@@ -196,7 +196,7 @@ func (db *MySQL) GetIndexes(table string) (results [][]string, err error) {
 	table = db.formatTableName(table)
 	rows, err := db.Connection.Query("SHOW INDEX FROM " + table)
 	if err != nil {
-		return results, err
+		return nil, err
 	}
 	defer rows.Close()
 
@@ -245,7 +245,7 @@ func (db *MySQL) GetRecords(table, where, sort string, offset, limit int) (pagin
 
 	paginatedRows, err := db.Connection.Query(query)
 	if err != nil {
-		return paginatedResults, totalRecords, err
+		return nil, 0, err
 	}
 
 	if isPaginationEnabled {
@@ -254,7 +254,7 @@ func (db *MySQL) GetRecords(table, where, sort string, offset, limit int) (pagin
 		rows := db.Connection.QueryRow(queryWithoutLimit)
 
 		if err != nil {
-			return paginatedResults, totalRecords, err
+			return nil, 0, err
 		}
 
 		rows.Scan(&totalRecords)
@@ -289,7 +289,7 @@ func (db *MySQL) GetRecords(table, where, sort string, offset, limit int) (pagin
 func (db *MySQL) ExecuteQuery(query string) (results [][]string, err error) {
 	rows, err := db.Connection.Query(query)
 	if err != nil {
-		return results, err
+		return nil, err
 	}
 
 	defer rows.Close()
@@ -438,8 +438,7 @@ func (db *MySQL) ExecutePendingChanges(changes []models.DbDmlChange, inserts []m
 	if err != nil {
 		return err
 	}
-
-	return err
+	return nil
 }
 
 func (db *MySQL) SetProvider(provider string) {

--- a/drivers/postgres.go
+++ b/drivers/postgres.go
@@ -22,7 +22,7 @@ type Postgres struct {
 }
 
 const (
-	DEFAULT_PORT = "5432"
+	defaultPort = "5432"
 )
 
 func (db *Postgres) Connect(urlstr string) (err error) {
@@ -582,7 +582,7 @@ func (db *Postgres) SwitchDatabase(database string) error {
 	dbname := parsedConn.Path
 
 	if port == "" {
-		port = DEFAULT_PORT
+		port = defaultPort
 	}
 
 	if dbname == "" {

--- a/drivers/postgres.go
+++ b/drivers/postgres.go
@@ -63,14 +63,14 @@ func (db *Postgres) TestConnection(urlstr string) error {
 func (db *Postgres) GetDatabases() (databases []string, err error) {
 	rows, err := db.Connection.Query("SELECT datname FROM pg_database;")
 	if err != nil {
-		return databases, err
+		return nil, err
 	}
 
 	for rows.Next() {
 		var database string
 		err := rows.Scan(&database)
 		if err != nil {
-			return databases, err
+			return nil, err
 		}
 		databases = append(databases, database)
 	}
@@ -86,7 +86,7 @@ func (db *Postgres) GetTables(database string) (tables map[string][]string, err 
 	if database != db.CurrentDatabase {
 		err = db.SwitchDatabase(database)
 		if err != nil {
-			return tables, err
+			return nil, err
 		}
 		switchDatabase = true
 	}
@@ -96,10 +96,10 @@ func (db *Postgres) GetTables(database string) (tables map[string][]string, err 
 		if switchDatabase {
 			err = db.SwitchDatabase(db.PreviousDatabase)
 			if err != nil {
-				return tables, err
+				return nil, err
 			}
 		}
-		return tables, err
+		return tables, nil
 	}
 
 	for rows.Next() {
@@ -120,13 +120,13 @@ func (db *Postgres) GetTableColumns(database, table string) (results [][]string,
 	tableName := strings.Split(table, ".")[1]
 	rows, err := db.Connection.Query(fmt.Sprintf("SELECT column_name, data_type, is_nullable, column_default FROM information_schema.columns WHERE table_catalog = '%s' AND table_schema = '%s' AND table_name = '%s' ORDER by ordinal_position", database, tableSchema, tableName))
 	if err != nil {
-		return results, err
+		return nil, err
 	}
 	defer rows.Close()
 
 	columns, err := rows.Columns()
 	if err != nil {
-		return results, err
+		return nil, err
 	}
 
 	results = append(results, columns)
@@ -172,14 +172,14 @@ func (db *Postgres) GetConstraints(table string) (constraints [][]string, error 
             AND tc.table_name = '%s'
             `, tableSchema, tableName))
 	if err != nil {
-		return constraints, err
+		return nil, err
 	}
 
 	defer rows.Close()
 
 	columns, err := rows.Columns()
 	if err != nil {
-		return constraints, err
+		return nil, err
 	}
 
 	constraints = append(constraints, columns)
@@ -226,14 +226,14 @@ func (db *Postgres) GetForeignKeys(table string) (foreignKeys [][]string, error 
             AND tc.table_name = '%s'
   `, tableSchema, tableName))
 	if err != nil {
-		return foreignKeys, err
+		return nil, err
 	}
 
 	defer rows.Close()
 
 	columns, err := rows.Columns()
 	if err != nil {
-		return foreignKeys, err
+		return nil, err
 	}
 
 	foreignKeys = append(foreignKeys, columns)
@@ -289,7 +289,7 @@ func (db *Postgres) GetIndexes(table string) (indexes [][]string, error error) {
             i.relname
   `, tableSchema, tableName))
 	if err != nil {
-		return indexes, err
+		return nil, err
 	}
 	defer rows.Close()
 
@@ -337,7 +337,7 @@ func (db *Postgres) GetRecords(table, where, sort string, offset, limit int) (re
 
 	paginatedRows, err := db.Connection.Query(query)
 	if err != nil {
-		return records, totalRecords, err
+		return nil, 0, err
 	}
 
 	if isPaginationEnabled {
@@ -346,7 +346,7 @@ func (db *Postgres) GetRecords(table, where, sort string, offset, limit int) (re
 		rows := db.Connection.QueryRow(queryWithoutLimit)
 
 		if err != nil {
-			return records, totalRecords, err
+			return nil, 0, err
 		}
 
 		err = rows.Scan(&totalRecords)
@@ -412,7 +412,7 @@ func (db *Postgres) ExecuteDMLStatement(query string) (result string, err error)
 func (db *Postgres) ExecuteQuery(query string) (results [][]string, err error) {
 	rows, err := db.Connection.Query(query)
 	if err != nil {
-		return results, err
+		return nil, err
 	}
 
 	defer rows.Close()
@@ -531,7 +531,7 @@ func (db *Postgres) ExecutePendingChanges(changes []models.DbDmlChange, inserts 
 		return err
 	}
 
-	return err
+	return nil
 }
 
 func (db *Postgres) SetProvider(provider string) {

--- a/drivers/postgres.go
+++ b/drivers/postgres.go
@@ -306,7 +306,10 @@ func (db *Postgres) GetIndexes(table string) (indexes [][]string, err error) {
 	}
 	defer rows.Close()
 
-	columns, _ := rows.Columns()
+	columns, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
 
 	indexes = append(indexes, columns)
 
@@ -373,7 +376,10 @@ func (db *Postgres) GetRecords(table, where, sort string, offset, limit int) (re
 		defer paginatedRows.Close()
 	}
 
-	columns, _ := paginatedRows.Columns()
+	columns, err := paginatedRows.Columns()
+	if err != nil {
+		return nil, 0, err
+	}
 
 	records = append(records, columns)
 
@@ -418,14 +424,15 @@ func (db *Postgres) DeleteRecord(table, primaryKeyColumnName, primaryKeyValue st
 
 func (db *Postgres) ExecuteDMLStatement(query string) (result string, err error) {
 	res, err := db.Connection.Exec(query)
-
 	if err != nil {
 		return result, err
-	} else {
-		rowsAffected, _ := res.RowsAffected()
-
-		return fmt.Sprintf("%d rows affected", rowsAffected), err
 	}
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return result, err
+	}
+
+	return fmt.Sprintf("%d rows affected", rowsAffected), nil
 }
 
 func (db *Postgres) ExecuteQuery(query string) (results [][]string, err error) {
@@ -436,7 +443,10 @@ func (db *Postgres) ExecuteQuery(query string) (results [][]string, err error) {
 
 	defer rows.Close()
 
-	columns, _ := rows.Columns()
+	columns, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
 
 	results = append(results, columns)
 

--- a/drivers/postgres.go
+++ b/drivers/postgres.go
@@ -115,7 +115,7 @@ func (db *Postgres) GetTables(database string) (tables map[string][]string, err 
 	return tables, nil
 }
 
-func (db *Postgres) GetTableColumns(database, table string) (results [][]string, error error) {
+func (db *Postgres) GetTableColumns(database, table string) (results [][]string, err error) {
 	tableSchema := strings.Split(table, ".")[0]
 	tableName := strings.Split(table, ".")[1]
 	rows, err := db.Connection.Query(fmt.Sprintf("SELECT column_name, data_type, is_nullable, column_default FROM information_schema.columns WHERE table_catalog = '%s' AND table_schema = '%s' AND table_name = '%s' ORDER by ordinal_position", database, tableSchema, tableName))
@@ -150,7 +150,7 @@ func (db *Postgres) GetTableColumns(database, table string) (results [][]string,
 	return
 }
 
-func (db *Postgres) GetConstraints(table string) (constraints [][]string, error error) {
+func (db *Postgres) GetConstraints(table string) (constraints [][]string, err error) {
 	splitTableString := strings.Split(table, ".")
 	tableSchema := splitTableString[0]
 	tableName := splitTableString[1]
@@ -203,7 +203,7 @@ func (db *Postgres) GetConstraints(table string) (constraints [][]string, error 
 	return
 }
 
-func (db *Postgres) GetForeignKeys(table string) (foreignKeys [][]string, error error) {
+func (db *Postgres) GetForeignKeys(table string) (foreignKeys [][]string, err error) {
 	splitTableString := strings.Split(table, ".")
 	tableSchema := splitTableString[0]
 	tableName := splitTableString[1]
@@ -257,7 +257,7 @@ func (db *Postgres) GetForeignKeys(table string) (foreignKeys [][]string, error 
 	return
 }
 
-func (db *Postgres) GetIndexes(table string) (indexes [][]string, error error) {
+func (db *Postgres) GetIndexes(table string) (indexes [][]string, err error) {
 	splitTableString := strings.Split(table, ".")
 	tableSchema := splitTableString[0]
 	tableName := splitTableString[1]

--- a/drivers/postgres.go
+++ b/drivers/postgres.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	_ "github.com/lib/pq"
 	"github.com/xo/dburl"
 
 	"github.com/jorgerojas26/lazysql/models"

--- a/drivers/postgres.go
+++ b/drivers/postgres.go
@@ -7,10 +7,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/jorgerojas26/lazysql/models"
+	_ "github.com/lib/pq"
 	"github.com/xo/dburl"
 
-	_ "github.com/lib/pq"
+	"github.com/jorgerojas26/lazysql/models"
 )
 
 type Postgres struct {

--- a/drivers/sqlite.go
+++ b/drivers/sqlite.go
@@ -7,9 +7,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/jorgerojas26/lazysql/models"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/xo/dburl"
+
+	"github.com/jorgerojas26/lazysql/models"
 )
 
 type SQLite struct {

--- a/drivers/sqlite.go
+++ b/drivers/sqlite.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	_ "github.com/mattn/go-sqlite3"
 	"github.com/xo/dburl"
 
 	"github.com/jorgerojas26/lazysql/models"

--- a/drivers/sqlite.go
+++ b/drivers/sqlite.go
@@ -213,7 +213,10 @@ func (db *SQLite) GetIndexes(table string) (results [][]string, err error) {
 	}
 	defer rows.Close()
 
-	columns, _ := rows.Columns()
+	columns, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
 
 	results = append(results, columns)
 
@@ -283,7 +286,10 @@ func (db *SQLite) GetRecords(table, where, sort string, offset, limit int) (pagi
 		defer paginatedRows.Close()
 	}
 
-	columns, _ := paginatedRows.Columns()
+	columns, err := paginatedRows.Columns()
+	if err != nil {
+		return nil, 0, err
+	}
 
 	paginatedResults = append(paginatedResults, columns)
 
@@ -322,7 +328,10 @@ func (db *SQLite) ExecuteQuery(query string) (results [][]string, err error) {
 
 	defer rows.Close()
 
-	columns, _ := rows.Columns()
+	columns, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
 
 	results = append(results, columns)
 
@@ -369,14 +378,16 @@ func (db *SQLite) DeleteRecord(table, primaryKeyColumnName, primaryKeyValue stri
 
 func (db *SQLite) ExecuteDMLStatement(query string) (result string, err error) {
 	res, err := db.Connection.Exec(query)
-
 	if err != nil {
-		return result, err
-	} else {
-		rowsAffected, _ := res.RowsAffected()
-
-		return fmt.Sprintf("%d rows affected", rowsAffected), err
+		return "", err
 	}
+
+	rowsAffected, err := res.RowsAffected()
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%d rows affected", rowsAffected), nil
 }
 
 func (db *SQLite) ExecutePendingChanges(changes []models.DbDmlChange, inserts []models.DbInsert) (err error) {

--- a/drivers/sqlite.go
+++ b/drivers/sqlite.go
@@ -84,7 +84,7 @@ func (db *SQLite) GetTables(database string) (map[string][]string, error) {
 }
 
 func (db *SQLite) GetTableColumns(database, table string) (results [][]string, err error) {
-	rows, err := db.Connection.Query("PRAGMA table_info(" + table + ")")
+	rows, err := db.Connection.Query(fmt.Sprintf("PRAGMA %s.table_info(%s)", database, table))
 	if err != nil {
 		return nil, err
 	}

--- a/drivers/sqlite.go
+++ b/drivers/sqlite.go
@@ -343,14 +343,14 @@ func (db *SQLite) DeleteRecord(table, primaryKeyColumnName, primaryKeyValue stri
 }
 
 func (db *SQLite) ExecuteDMLStatement(query string) (result string, err error) {
-	res, error := db.Connection.Exec(query)
+	res, err := db.Connection.Exec(query)
 
-	if error != nil {
-		return result, error
+	if err != nil {
+		return result, err
 	} else {
 		rowsAffected, _ := res.RowsAffected()
 
-		return fmt.Sprintf("%d rows affected", rowsAffected), error
+		return fmt.Sprintf("%d rows affected", rowsAffected), err
 	}
 }
 
@@ -412,9 +412,9 @@ func (db *SQLite) ExecutePendingChanges(changes []models.DbDmlChange, inserts []
 		columnsToBeInserted := insert.Columns
 
 		for _, value := range insert.Values {
-			_, error := strconv.ParseFloat(value, 64)
+			_, err := strconv.ParseFloat(value, 64)
 
-			if error != nil {
+			if err != nil {
 				values = append(values, fmt.Sprintf("\"%s\"", value))
 			} else {
 				values = append(values, value)
@@ -426,9 +426,9 @@ func (db *SQLite) ExecutePendingChanges(changes []models.DbDmlChange, inserts []
 		queries = append(queries, query)
 	}
 
-	tx, error := db.Connection.Begin()
-	if error != nil {
-		return error
+	tx, err := db.Connection.Begin()
+	if err != nil {
+		return err
 	}
 
 	for _, query := range queries {

--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,6 @@ require (
 	github.com/gdamore/tcell/v2 v2.7.0
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/google/uuid v1.5.0
-	github.com/lib/pq v1.10.9
-	github.com/mattn/go-sqlite3 v1.14.19
 	github.com/pelletier/go-toml/v2 v2.1.1
 	github.com/rivo/tview v0.0.0-20240101144852-b3bd1aa5e9f2
 	github.com/xo/dburl v0.20.2

--- a/go.sum
+++ b/go.sum
@@ -10,14 +10,10 @@ github.com/go-sql-driver/mysql v1.7.1 h1:lUIinVbN1DY0xBg0eMOzmmtGoHwWBbvnWubQUrt
 github.com/go-sql-driver/mysql v1.7.1/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/google/uuid v1.5.0 h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=
 github.com/google/uuid v1.5.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
-github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
-github.com/mattn/go-sqlite3 v1.14.19 h1:fhGleo2h1p8tVChob4I9HpmVFIAkKGpiukdrgQbWfGI=
-github.com/mattn/go-sqlite3 v1.14.19/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/pelletier/go-toml/v2 v2.1.1 h1:LWAJwfNvjQZCFIDKWYQaM62NcYeYViCmWIwmOStowAI=
 github.com/pelletier/go-toml/v2 v2.1.1/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/helpers/config.go
+++ b/helpers/config.go
@@ -4,9 +4,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/jorgerojas26/lazysql/models"
-
 	"github.com/pelletier/go-toml/v2"
+
+	"github.com/jorgerojas26/lazysql/models"
 )
 
 type Config struct {

--- a/keymap/map.go
+++ b/keymap/map.go
@@ -2,6 +2,7 @@ package keymap
 
 import (
 	"github.com/gdamore/tcell/v2"
+
 	"github.com/jorgerojas26/lazysql/commands"
 )
 

--- a/main.go
+++ b/main.go
@@ -5,10 +5,10 @@ import (
 	"log"
 	"os"
 
+	"github.com/go-sql-driver/mysql"
+
 	"github.com/jorgerojas26/lazysql/app"
 	"github.com/jorgerojas26/lazysql/components"
-
-	"github.com/go-sql-driver/mysql"
 )
 
 var version = "dev"

--- a/main.go
+++ b/main.go
@@ -14,7 +14,10 @@ import (
 var version = "dev"
 
 func main() {
-	mysql.SetLogger(log.New(io.Discard, "", 0))
+	err := mysql.SetLogger(log.New(io.Discard, "", 0))
+	if err != nil {
+		panic(err)
+	}
 
 	// check if "version" arg is passed
 	argsWithProg := os.Args


### PR DESCRIPTION
- **chore: use Go canonical way to return errors**
- **chore: use the canonical name for error variable**
- **ci: add golangci-lint configuration file**
- **fix: catch errors reported by errcheck linter**
- **fix: make sure to catch all errors in drivers**
- **ci: enable more linters**
- **chore: fix import orders**
- **chore: remove dot import and use type alias**
- **chore: remove else when previous if ends with a return**
- **chore: remove type or default value when obvious**
- **chore: use go initialism for variable name**
- **chore: no uppercase constant in Go**
- **chore: remove suspicious blank imports**
- **fix: make sure to use the database name when getting table columns**
- **ci: enable golang-lint in GitHub actions**

Fixes #71 

Related to #14 
