### PR TITLE
feat: add input filter to tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ odbc+postgres://user:pass@localhost:port/dbname?option1=
 
 - [ ] Support for NoSQL databases
 - [ ] Columns and indexes creation through TUI
-- [ ] Table tree input filter
+- [x] Table tree input filter
 - [ ] Custom keybindings
 - [x] Show keybindings on a modal
 - [x] Rewrite row `create`, `update` and `delete` logic

--- a/app/Keymap.go
+++ b/app/Keymap.go
@@ -40,6 +40,7 @@ func (c KeymapSystem) Resolve(event *tcell.EventKey) cmd.Command {
 const (
 	HomeGroup       = "home"
 	TreeGroup       = "tree"
+	TreeFilterGroup = "treefilter"
 	TableGroup      = "table"
 	EditorGroup     = "editor"
 	ConnectionGroup = "connection"
@@ -73,6 +74,15 @@ var Keymaps = KeymapSystem{
 			Bind{Key: Key{Code: tcell.KeyDown}, Cmd: cmd.MoveDown, Description: "Go down"},
 			Bind{Key: Key{Char: 'k'}, Cmd: cmd.MoveUp, Description: "Go up"},
 			Bind{Key: Key{Code: tcell.KeyUp}, Cmd: cmd.MoveUp, Description: "Go up"},
+			Bind{Key: Key{Char: '/'}, Cmd: cmd.Search, Description: "Search"},
+			Bind{Key: Key{Char: 'n'}, Cmd: cmd.NextFoundNode, Description: "Go to next found node"},
+			Bind{Key: Key{Char: 'p'}, Cmd: cmd.PreviousFoundNode, Description: "Go to previous found node"},
+			Bind{Key: Key{Char: 'c'}, Cmd: cmd.TreeCollapseAll, Description: "Collapse all"},
+			Bind{Key: Key{Char: 'e'}, Cmd: cmd.ExpandAll, Description: "Expand all"},
+		},
+		TreeFilterGroup: {
+			Bind{Key: Key{Code: tcell.KeyEscape}, Cmd: cmd.UnfocusTreeFilter, Description: "Unfocus tree filter"},
+			Bind{Key: Key{Code: tcell.KeyEnter}, Cmd: cmd.CommitTreeFilter, Description: "Commit tree filter search"},
 		},
 		TableGroup: {
 			Bind{Key: Key{Char: '/'}, Cmd: cmd.Search, Description: "Search"},

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -54,6 +54,12 @@ const (
 	AppendNewRow
 	SortAsc
 	SortDesc
+	UnfocusTreeFilter
+	CommitTreeFilter
+	NextFoundNode
+	PreviousFoundNode
+	TreeCollapseAll
+	ExpandAll
 
 	// Connection
 	NewConnection
@@ -161,6 +167,18 @@ func (c Command) String() string {
 		return "ForeignKeysMenu"
 	case IndexesMenu:
 		return "IndexesMenu"
+	case UnfocusTreeFilter:
+		return "UnfocusTreeFilter"
+	case CommitTreeFilter:
+		return "CommitTreeFilter"
+	case NextFoundNode:
+		return "NextFoundNode"
+	case PreviousFoundNode:
+		return "PreviousFoundNode"
+	case TreeCollapseAll:
+		return "TreeCollapseAll"
+	case ExpandAll:
+		return "ExpandAll"
 	}
 	return "Unknown"
 }

--- a/components/ConnectionSelection.go
+++ b/components/ConnectionSelection.go
@@ -180,7 +180,7 @@ func (cs *ConnectionSelection) Connect(connection models.Connection) {
 
 			MainPages.SwitchToPage(connection.URL)
 			newHome.Tree.SetCurrentNode(newHome.Tree.GetRoot())
-			newHome.Tree.SetTitle(fmt.Sprintf("%s (%s)", connection.Name, strings.ToUpper(connection.Provider)))
+			newHome.Tree.Wrapper.SetTitle(fmt.Sprintf("%s (%s)", connection.Name, strings.ToUpper(connection.Provider)))
 			App.SetFocus(newHome.Tree)
 			App.Draw()
 		}

--- a/components/Home.go
+++ b/components/Home.go
@@ -48,7 +48,7 @@ func NewHomePage(connection models.Connection, dbdriver drivers.Driver) *Home {
 	go home.subscribeToTreeChanges()
 
 	leftWrapper.SetBorderColor(tview.Styles.InverseTextColor)
-	leftWrapper.AddItem(tree, 0, 1, true)
+	leftWrapper.AddItem(tree.Wrapper, 0, 1, true)
 
 	rightWrapper.SetBorderColor(tview.Styles.InverseTextColor)
 	rightWrapper.SetBorder(true)
@@ -113,6 +113,13 @@ func (home *Home) subscribeToTreeChanges() {
 			}
 
 			app.App.ForceDraw()
+		case "IsFiltering":
+			isFiltering := stateChange.Value.(bool)
+			if isFiltering {
+				home.SetInputCapture(nil)
+			} else {
+				home.SetInputCapture(home.homeInputCapture)
+			}
 		}
 	}
 }


### PR DESCRIPTION
1. Add an input to search on the tree
2. Add `n` and `p` keybindings on the tree to cycle between found nodes.
    - `n` = Next
    - `p` = Previous
3. Add `c` and `e` keybindings on the tree to collapse and expand all nodes
    - `c` = collapse all
    - `e` = expand all

Fixes #83 

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/4b0fb52e-8e03-4db6-be04-fb5f62d09ed8">