### PR TITLE
fix: error handing for row cursors

### DIFF
--- a/drivers/postgres.go
+++ b/drivers/postgres.go
@@ -67,15 +67,7 @@ func (db *Postgres) GetDatabases() (databases []string, err error) {
 	if err != nil {
 		return nil, err
 	}
-
 	defer rows.Close()
-
-	rowsErr := rows.Err()
-
-	if rowsErr != nil {
-		err = rowsErr
-		return nil, err
-	}
 
 	for rows.Next() {
 		var database string
@@ -84,6 +76,9 @@ func (db *Postgres) GetDatabases() (databases []string, err error) {
 			return nil, err
 		}
 		databases = append(databases, database)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 
 	return databases, nil
@@ -113,29 +108,23 @@ func (db *Postgres) GetTables(database string) (tables map[string][]string, err 
 
 	query := "SELECT table_name, table_schema FROM information_schema.tables WHERE table_catalog = $1"
 	rows, err := db.Connection.Query(query, database)
-
-	if rows != nil {
-		rowsErr := rows.Err()
-
-		if rowsErr != nil {
-			err = rowsErr
-		}
-
-		defer rows.Close()
-
-		for rows.Next() {
-			var tableName string
-			var tableSchema string
-
-			err = rows.Scan(&tableName, &tableSchema)
-
-			tables[tableSchema] = append(tables[tableSchema], tableName)
-
-		}
-
-	}
-
 	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var (
+			tableName   string
+			tableSchema string
+		)
+		if err := rows.Scan(&tableName, &tableSchema); err != nil {
+			return nil, err
+		}
+
+		tables[tableSchema] = append(tables[tableSchema], tableName)
+	}
+	if err := rows.Err(); err != nil {
 		return nil, err
 	}
 
@@ -176,46 +165,35 @@ func (db *Postgres) GetTableColumns(database, table string) (results [][]string,
 	query := "SELECT column_name, data_type, is_nullable, column_default FROM information_schema.columns WHERE table_catalog = $1 AND table_schema = $2 AND table_name = $3 ORDER by ordinal_position"
 
 	rows, err := db.Connection.Query(query, database, tableSchema, tableName)
-
-	if rows != nil {
-
-		rowsErr := rows.Err()
-
-		if rowsErr != nil {
-			err = rowsErr
-		}
-
-		defer rows.Close()
-
-		columns, columnsError := rows.Columns()
-
-		if columnsError != nil {
-			err = columnsError
-		}
-
-		results = append(results, columns)
-
-		for rows.Next() {
-			rowValues := make([]interface{}, len(columns))
-
-			for i := range columns {
-				rowValues[i] = new(sql.RawBytes)
-			}
-
-			err = rows.Scan(rowValues...)
-
-			var row []string
-			for _, col := range rowValues {
-				row = append(row, string(*col.(*sql.RawBytes)))
-			}
-
-			results = append(results, row)
-		}
-
-	}
-
 	if err != nil {
 		return nil, err
+	}
+	defer rows.Close()
+
+	columns, columnsError := rows.Columns()
+	if columnsError != nil {
+		err = columnsError
+	}
+
+	results = append(results, columns)
+
+	for rows.Next() {
+		rowValues := make([]interface{}, len(columns))
+
+		for i := range columns {
+			rowValues[i] = new(sql.RawBytes)
+		}
+
+		if err := rows.Scan(rowValues...); err != nil {
+			return nil, err
+		}
+
+		var row []string
+		for _, col := range rowValues {
+			row = append(row, string(*col.(*sql.RawBytes)))
+		}
+
+		results = append(results, row)
 	}
 
 	return
@@ -268,43 +246,36 @@ func (db *Postgres) GetConstraints(database, table string) (constraints [][]stri
 			AND tc.table_schema = '%s'
             AND tc.table_name = '%s'
             `, tableSchema, tableName))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
 
-	if rows != nil {
-
-		rowsErr := rows.Err()
-
-		if rowsErr != nil {
-			err = rowsErr
-		}
-
-		defer rows.Close()
-
-		columns, columnsError := rows.Columns()
-
-		if columnsError != nil {
-			err = columnsError
-		}
-
-		constraints = append(constraints, columns)
-
-		for rows.Next() {
-			rowValues := make([]interface{}, len(columns))
-			for i := range columns {
-				rowValues[i] = new(sql.RawBytes)
-			}
-
-			err = rows.Scan(rowValues...)
-
-			var row []string
-			for _, col := range rowValues {
-				row = append(row, string(*col.(*sql.RawBytes)))
-			}
-
-			constraints = append(constraints, row)
-		}
+	columns, columnsError := rows.Columns()
+	if columnsError != nil {
+		err = columnsError
 	}
 
-	if err != nil {
+	constraints = append(constraints, columns)
+
+	for rows.Next() {
+		rowValues := make([]interface{}, len(columns))
+		for i := range columns {
+			rowValues[i] = new(sql.RawBytes)
+		}
+
+		if err := rows.Scan(rowValues...); err != nil {
+			return nil, err
+		}
+
+		var row []string
+		for _, col := range rowValues {
+			row = append(row, string(*col.(*sql.RawBytes)))
+		}
+
+		constraints = append(constraints, row)
+	}
+	if err := rows.Err(); err != nil {
 		return nil, err
 	}
 
@@ -359,43 +330,36 @@ func (db *Postgres) GetForeignKeys(database, table string) (foreignKeys [][]stri
           	AND tc.table_schema = '%s'
             AND tc.table_name = '%s'
   `, tableSchema, tableName))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
 
-	if rows != nil {
-
-		rowsErr := rows.Err()
-
-		if rowsErr != nil {
-			err = rowsErr
-		}
-
-		defer rows.Close()
-
-		columns, columnsError := rows.Columns()
-
-		if columnsError != nil {
-			err = columnsError
-		}
-
-		foreignKeys = append(foreignKeys, columns)
-
-		for rows.Next() {
-			rowValues := make([]interface{}, len(columns))
-			for i := range columns {
-				rowValues[i] = new(sql.RawBytes)
-			}
-
-			err = rows.Scan(rowValues...)
-
-			var row []string
-			for _, col := range rowValues {
-				row = append(row, string(*col.(*sql.RawBytes)))
-			}
-
-			foreignKeys = append(foreignKeys, row)
-		}
+	columns, columnsError := rows.Columns()
+	if columnsError != nil {
+		err = columnsError
 	}
 
-	if err != nil {
+	foreignKeys = append(foreignKeys, columns)
+
+	for rows.Next() {
+		rowValues := make([]interface{}, len(columns))
+		for i := range columns {
+			rowValues[i] = new(sql.RawBytes)
+		}
+
+		if err := rows.Scan(rowValues...); err != nil {
+			return nil, err
+		}
+
+		var row []string
+		for _, col := range rowValues {
+			row = append(row, string(*col.(*sql.RawBytes)))
+		}
+
+		foreignKeys = append(foreignKeys, row)
+	}
+	if err := rows.Err(); err != nil {
 		return nil, err
 	}
 
@@ -459,43 +423,36 @@ func (db *Postgres) GetIndexes(database, table string) (indexes [][]string, err 
             t.relname,
             i.relname
   `, tableSchema, tableName))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
 
-	if rows != nil {
-
-		rowsErr := rows.Err()
-
-		if rowsErr != nil {
-			err = rowsErr
-		}
-
-		defer rows.Close()
-
-		columns, columnsError := rows.Columns()
-
-		if columnsError != nil {
-			err = columnsError
-		}
-
-		indexes = append(indexes, columns)
-
-		for rows.Next() {
-			rowValues := make([]interface{}, len(columns))
-			for i := range columns {
-				rowValues[i] = new(sql.RawBytes)
-			}
-
-			err = rows.Scan(rowValues...)
-
-			var row []string
-			for _, col := range rowValues {
-				row = append(row, string(*col.(*sql.RawBytes)))
-			}
-
-			indexes = append(indexes, row)
-		}
+	columns, columnsError := rows.Columns()
+	if columnsError != nil {
+		err = columnsError
 	}
 
-	if err != nil {
+	indexes = append(indexes, columns)
+
+	for rows.Next() {
+		rowValues := make([]interface{}, len(columns))
+		for i := range columns {
+			rowValues[i] = new(sql.RawBytes)
+		}
+
+		if err := rows.Scan(rowValues...); err != nil {
+			return nil, err
+		}
+
+		var row []string
+		for _, col := range rowValues {
+			row = append(row, string(*col.(*sql.RawBytes)))
+		}
+
+		indexes = append(indexes, row)
+	}
+	if err := rows.Err(); err != nil {
 		return nil, err
 	}
 
@@ -555,57 +512,48 @@ func (db *Postgres) GetRecords(database, table, where, sort string, offset, limi
 	query += " LIMIT $1 OFFSET $2"
 
 	paginatedRows, err := db.Connection.Query(query, limit, offset)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer paginatedRows.Close()
 
-	if paginatedRows != nil {
-
-		rowsErr := paginatedRows.Err()
-
-		defer paginatedRows.Close()
-
-		if rowsErr != nil {
-			err = rowsErr
-		}
-
-		countQuery := "SELECT COUNT(*) FROM "
-		countQuery += formattedTableName
-
-		rows := db.Connection.QueryRow(countQuery)
-
-		rowsErr = rows.Err()
-
-		if rowsErr != nil {
-			err = rowsErr
-		}
-
-		err = rows.Scan(&totalRecords)
-
-		columns, columnsError := paginatedRows.Columns()
-
-		if columnsError != nil {
-			err = columnsError
-		}
-
-		records = append(records, columns)
-
-		for paginatedRows.Next() {
-			rowValues := make([]interface{}, len(columns))
-			for i := range columns {
-				rowValues[i] = new(sql.RawBytes)
-			}
-
-			err = paginatedRows.Scan(rowValues...)
-
-			var row []string
-			for _, col := range rowValues {
-				row = append(row, string(*col.(*sql.RawBytes)))
-			}
-
-			records = append(records, row)
-
-		}
+	columns, columnsError := paginatedRows.Columns()
+	if columnsError != nil {
+		return nil, 0, columnsError
 	}
 
-	if err != nil {
+	records = append(records, columns)
+
+	for paginatedRows.Next() {
+		rowValues := make([]interface{}, len(columns))
+		for i := range columns {
+			rowValues[i] = new(sql.RawBytes)
+		}
+
+		if err := paginatedRows.Scan(rowValues...); err != nil {
+			return nil, 0, err
+		}
+
+		var row []string
+		for _, col := range rowValues {
+			row = append(row, string(*col.(*sql.RawBytes)))
+		}
+
+		records = append(records, row)
+
+	}
+	if err := paginatedRows.Err(); err != nil {
+		return nil, 0, err
+	}
+	// close to release the connection
+	if err := paginatedRows.Close(); err != nil {
+		return nil, 0, err
+	}
+
+	countQuery := "SELECT COUNT(*) FROM "
+	countQuery += formattedTableName
+	row := db.Connection.QueryRow(countQuery)
+	if err := row.Scan(&totalRecords); err != nil {
 		return nil, 0, err
 	}
 
@@ -740,14 +688,7 @@ func (db *Postgres) ExecuteQuery(query string) (results [][]string, err error) {
 	if err != nil {
 		return nil, err
 	}
-
 	defer rows.Close()
-
-	rowsErr := rows.Err()
-
-	if rowsErr != nil {
-		err = rowsErr
-	}
 
 	columns, err := rows.Columns()
 	if err != nil {
@@ -773,7 +714,9 @@ func (db *Postgres) ExecuteQuery(query string) (results [][]string, err error) {
 		}
 
 		results = append(results, row)
-
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 
 	return
@@ -869,6 +812,7 @@ func (db *Postgres) ExecutePendingChanges(changes []models.DbDmlChange) (err err
 	if err != nil {
 		return err
 	}
+	defer trx.Rollback()
 
 	for _, query := range query {
 		logger.Info(query.Query, map[string]any{"args": query.Args})

--- a/drivers/sqlite.go
+++ b/drivers/sqlite.go
@@ -468,7 +468,7 @@ func (db *SQLite) ExecuteDMLStatement(query string) (result string, err error) {
 }
 
 func (db *SQLite) ExecutePendingChanges(changes []models.DbDmlChange) (err error) {
-	var query []models.Query
+	var queries []models.Query
 
 	for _, change := range changes {
 		columnNames := []string{}
@@ -506,7 +506,7 @@ func (db *SQLite) ExecutePendingChanges(changes []models.DbDmlChange) (err error
 				Args:  values,
 			}
 
-			query = append(query, newQuery)
+			queries = append(queries, newQuery)
 		case models.DmlUpdateType:
 			queryStr := "UPDATE "
 			queryStr += db.formatTableName(change.Table)
@@ -531,7 +531,7 @@ func (db *SQLite) ExecutePendingChanges(changes []models.DbDmlChange) (err error
 				Args:  args,
 			}
 
-			query = append(query, newQuery)
+			queries = append(queries, newQuery)
 		case models.DmlDeleteType:
 			queryStr := "DELETE FROM "
 			queryStr += db.formatTableName(change.Table)
@@ -542,30 +542,10 @@ func (db *SQLite) ExecutePendingChanges(changes []models.DbDmlChange) (err error
 				Args:  []interface{}{change.PrimaryKeyValue},
 			}
 
-			query = append(query, newQuery)
+			queries = append(queries, newQuery)
 		}
 	}
-
-	trx, err := db.Connection.Begin()
-	if err != nil {
-		return err
-	}
-	defer trx.Rollback()
-
-	for _, query := range query {
-		logger.Info(query.Query, map[string]any{"args": query.Args})
-		_, err := trx.Exec(query.Query, query.Args...)
-		if err != nil {
-			return err
-		}
-	}
-
-	err = trx.Commit()
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return queriesInTransaction(db.Connection, queries)
 }
 
 func (db *SQLite) SetProvider(provider string) {

--- a/drivers/sqlite.go
+++ b/drivers/sqlite.go
@@ -45,12 +45,6 @@ func (db *SQLite) GetDatabases() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	rowsErr := rows.Err()
-	if rowsErr != nil {
-		return nil, rowsErr
-	}
-
 	defer rows.Close()
 
 	for rows.Next() {
@@ -65,6 +59,9 @@ func (db *SQLite) GetDatabases() ([]string, error) {
 
 		databases = append(databases, dbName)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 
 	return databases, nil
 }
@@ -78,12 +75,6 @@ func (db *SQLite) GetTables(database string) (map[string][]string, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	rowsErr := rows.Err()
-	if rowsErr != nil {
-		return nil, rowsErr
-	}
-
 	defer rows.Close()
 
 	tables := make(map[string][]string)
@@ -96,6 +87,9 @@ func (db *SQLite) GetTables(database string) (map[string][]string, error) {
 		}
 
 		tables[database] = append(tables[database], table)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 
 	return tables, nil
@@ -110,12 +104,6 @@ func (db *SQLite) GetTableColumns(_, table string) (results [][]string, err erro
 	if err != nil {
 		return nil, err
 	}
-
-	rowsErr := rows.Err()
-	if rowsErr != nil {
-		return nil, rowsErr
-	}
-
 	defer rows.Close()
 
 	columns, err := rows.Columns()
@@ -148,6 +136,9 @@ func (db *SQLite) GetTableColumns(_, table string) (results [][]string, err erro
 
 		results = append(results, row[1:])
 	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
 
 	return
 }
@@ -164,12 +155,6 @@ func (db *SQLite) GetConstraints(_, table string) (results [][]string, err error
 	if err != nil {
 		return nil, err
 	}
-
-	rowsErr := rows.Err()
-	if rowsErr != nil {
-		return nil, rowsErr
-	}
-
 	defer rows.Close()
 
 	columns, err := rows.Columns()
@@ -200,6 +185,9 @@ func (db *SQLite) GetConstraints(_, table string) (results [][]string, err error
 		}
 
 		results = append(results, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 
 	return
@@ -214,12 +202,6 @@ func (db *SQLite) GetForeignKeys(_, table string) (results [][]string, err error
 	if err != nil {
 		return nil, err
 	}
-
-	rowsErr := rows.Err()
-	if rowsErr != nil {
-		return nil, rowsErr
-	}
-
 	defer rows.Close()
 
 	columns, err := rows.Columns()
@@ -250,6 +232,9 @@ func (db *SQLite) GetForeignKeys(_, table string) (results [][]string, err error
 		}
 
 		results = append(results, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 
 	return
@@ -264,12 +249,6 @@ func (db *SQLite) GetIndexes(_, table string) (results [][]string, err error) {
 	if err != nil {
 		return nil, err
 	}
-
-	rowsErr := rows.Err()
-	if rowsErr != nil {
-		return nil, rowsErr
-	}
-
 	defer rows.Close()
 
 	columns, err := rows.Columns()
@@ -300,6 +279,9 @@ func (db *SQLite) GetIndexes(_, table string) (results [][]string, err error) {
 		}
 
 		results = append(results, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 
 	return
@@ -331,28 +313,7 @@ func (db *SQLite) GetRecords(_, table, where, sort string, offset, limit int) (p
 	if err != nil {
 		return nil, 0, err
 	}
-
-	rowsErr := paginatedRows.Err()
-
-	if rowsErr != nil {
-		return nil, 0, rowsErr
-	}
-
 	defer paginatedRows.Close()
-
-	countQuery := "SELECT COUNT(*) FROM "
-	countQuery += db.formatTableName(table)
-
-	rows := db.Connection.QueryRow(countQuery)
-
-	if err != nil {
-		return nil, 0, err
-	}
-
-	err = rows.Scan(&totalRecords)
-	if err != nil {
-		return nil, 0, err
-	}
 
 	columns, err := paginatedRows.Columns()
 	if err != nil {
@@ -378,7 +339,20 @@ func (db *SQLite) GetRecords(_, table, where, sort string, offset, limit int) (p
 		}
 
 		paginatedResults = append(paginatedResults, row)
+	}
+	if err := paginatedRows.Err(); err != nil {
+		return nil, 0, err
+	}
+	// close to release the connection
+	if err := paginatedRows.Close(); err != nil {
+		return nil, 0, err
+	}
 
+	countQuery := "SELECT COUNT(*) FROM "
+	countQuery += db.formatTableName(table)
+	row := db.Connection.QueryRow(countQuery)
+	if err := row.Scan(&totalRecords); err != nil {
+		return nil, 0, err
 	}
 
 	return
@@ -389,12 +363,6 @@ func (db *SQLite) ExecuteQuery(query string) (results [][]string, err error) {
 	if err != nil {
 		return nil, err
 	}
-
-	rowsErr := rows.Err()
-	if rowsErr != nil {
-		return nil, rowsErr
-	}
-
 	defer rows.Close()
 
 	columns, err := rows.Columns()
@@ -425,7 +393,9 @@ func (db *SQLite) ExecuteQuery(query string) (results [][]string, err error) {
 		}
 
 		results = append(results, row)
-
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 
 	return
@@ -580,6 +550,7 @@ func (db *SQLite) ExecutePendingChanges(changes []models.DbDmlChange) (err error
 	if err != nil {
 		return err
 	}
+	defer trx.Rollback()
 
 	for _, query := range query {
 		logger.Info(query.Query, map[string]any{"args": query.Args})

--- a/drivers/utils.go
+++ b/drivers/utils.go
@@ -1,0 +1,34 @@
+package drivers
+
+import (
+	"database/sql"
+	"errors"
+
+	"github.com/jorgerojas26/lazysql/helpers/logger"
+	"github.com/jorgerojas26/lazysql/models"
+)
+
+func queriesInTransaction(db *sql.DB, queries []models.Query) (err error) {
+	trx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		rErr := trx.Rollback()
+		// sql.ErrTxDone is returned when trx.Commit was already called
+		if !errors.Is(rErr, sql.ErrTxDone) {
+			err = errors.Join(err, rErr)
+		}
+	}()
+
+	for _, query := range queries {
+		logger.Info(query.Query, map[string]any{"args": query.Args})
+		if _, err := trx.Exec(query.Query, query.Args...); err != nil {
+			return err
+		}
+	}
+	if err := trx.Commit(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/drivers/utils_test.go
+++ b/drivers/utils_test.go
@@ -1,0 +1,116 @@
+package drivers
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	gomock "github.com/DATA-DOG/go-sqlmock"
+	"github.com/jorgerojas26/lazysql/models"
+)
+
+func Test_queriesInTransaction(t *testing.T) {
+	tests := []struct {
+		name                string
+		queries             []models.Query
+		setMockExpectations func(mock gomock.Sqlmock)
+		assertErr           func(t *testing.T, err error)
+	}{
+		{
+			name: "successful transaction",
+			queries: []models.Query{
+				{Query: "SELECT * FROM table"},
+			},
+			setMockExpectations: func(mock gomock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectExec("SELECT \\* FROM table").WillReturnResult(gomock.NewResult(0, 0))
+				mock.ExpectCommit()
+			},
+		},
+		{
+			name: "unsuccessful commit",
+			queries: []models.Query{
+				{Query: "SELECT * FROM table"},
+			},
+			setMockExpectations: func(mock gomock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectExec("SELECT \\* FROM table").WillReturnResult(gomock.NewResult(0, 0))
+				mock.ExpectCommit().WillReturnError(errors.New("commit error"))
+			},
+			assertErr: func(t *testing.T, err error) {
+				if !strings.Contains(err.Error(), "commit error") {
+					t.Errorf("expected error to contain 'commit error', got %v", err)
+				}
+			},
+		},
+		{
+			name: "failed query",
+			queries: []models.Query{
+				{Query: "SELECT * FROM table"},
+			},
+			setMockExpectations: func(mock gomock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectExec("SELECT \\* FROM table").WillReturnError(errors.New("query error"))
+				mock.ExpectRollback()
+			},
+			assertErr: func(t *testing.T, err error) {
+				if !strings.Contains(err.Error(), "query error") {
+					t.Errorf("expected error to contain 'commit error', got %v", err)
+				}
+			},
+		},
+		{
+			name: "failed 2nd query of three",
+			queries: []models.Query{
+				{Query: "SELECT * FROM table"},
+				{Query: "SELECT * FROM table"},
+				{Query: "SELECT * FROM table"},
+			},
+			setMockExpectations: func(mock gomock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectExec("SELECT \\* FROM table").WillReturnResult(gomock.NewResult(0, 0))
+				mock.ExpectExec("SELECT \\* FROM table").WillReturnError(errors.New("query error"))
+				mock.ExpectRollback()
+			},
+			assertErr: func(t *testing.T, err error) {
+				if !strings.Contains(err.Error(), "query error") {
+					t.Errorf("expected error to contain 'commit error', got %v", err)
+				}
+			},
+		},
+		{
+			name: "failed query and rollback",
+			queries: []models.Query{
+				{Query: "SELECT * FROM table"},
+			},
+			setMockExpectations: func(mock gomock.Sqlmock) {
+				mock.ExpectBegin()
+				mock.ExpectExec("SELECT \\* FROM table").WillReturnError(errors.New("query error"))
+				mock.ExpectRollback().WillReturnError(errors.New("rollback error"))
+			},
+			assertErr: func(t *testing.T, err error) {
+				errMsg := err.Error()
+				if !strings.Contains(errMsg, "query error") {
+					t.Errorf("expected error to contain 'commit error', got %v", err)
+				}
+				if !strings.Contains(errMsg, "rollback error") {
+					t.Errorf("expected error to contain 'rollback error', got %v", err)
+				}
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := gomock.New()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer db.Close()
+			tt.setMockExpectations(mock)
+			queryErr := queriesInTransaction(db, tt.queries)
+			if tt.assertErr != nil {
+				tt.assertErr(t, queryErr)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,12 @@ module github.com/jorgerojas26/lazysql
 go 1.20
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/atotto/clipboard v0.1.4
 	github.com/gdamore/tcell/v2 v2.7.0
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/google/uuid v1.6.0
+	github.com/lib/pq v1.10.9
 	github.com/pelletier/go-toml/v2 v2.1.1
 	github.com/rivo/tview v0.0.0-20240101144852-b3bd1aa5e9f2
 	github.com/xo/dburl v0.20.2
@@ -15,25 +17,21 @@ require (
 
 require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/gdamore/encoding v1.0.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
+	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-runewidth v0.0.15 // indirect
 	github.com/ncruces/go-strftime v0.1.9 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
+	github.com/rivo/uniseg v0.4.3 // indirect
+	golang.org/x/sys v0.22.0 // indirect
+	golang.org/x/term v0.15.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
 	modernc.org/gc/v3 v3.0.0-20240107210532-573471604cb6 // indirect
 	modernc.org/libc v1.55.3 // indirect
 	modernc.org/mathutil v1.6.0 // indirect
 	modernc.org/memory v1.8.0 // indirect
 	modernc.org/strutil v1.2.0 // indirect
 	modernc.org/token v1.1.0 // indirect
-)
-
-require (
-	github.com/gdamore/encoding v1.0.0 // indirect
-	github.com/lib/pq v1.10.9
-	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
-	github.com/mattn/go-runewidth v0.0.15 // indirect
-	github.com/rivo/uniseg v0.4.3 // indirect
-	golang.org/x/sys v0.22.0 // indirect
-	golang.org/x/term v0.15.0 // indirect
-	golang.org/x/text v0.14.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -16,6 +18,7 @@ github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=


### PR DESCRIPTION
`(*sql.Rows).Next()` can return `false` due to an error. The error must be handled by checking `(*sql.Rows).Err()`.

The transaction must be ended by commit or rollback to close the db connection. Calling rollback after commit is noop.

Don't call a query in the middle of cursor, as it may lead to a deadlock. The inner query may wait for a free connection, and the connection from the cursor can't be freed because it's stuck by the inner query waiting.