### PR TITLE
feat: refresh the current table.

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Support for multiple RDBMS is a work in progress.
 | [        | Focus previous tab                   |
 | ]        | Focus next tab                       |
 | X        | Close current tab                    |
+| R        | Refresh the current table            |
 
 ### Tree
 

--- a/app/Keymap.go
+++ b/app/Keymap.go
@@ -96,6 +96,7 @@ var Keymaps = KeymapSystem{
 			Bind{Key: Key{Char: 'y'}, Cmd: cmd.Copy, Description: "Copy cell to clipboard"},
 			Bind{Key: Key{Char: 'o'}, Cmd: cmd.AppendNewRow, Description: "Append new row"},
 			Bind{Key: Key{Char: 'J'}, Cmd: cmd.SortDesc, Description: "Sort descending"},
+			Bind{Key: Key{Char: 'R'}, Cmd: cmd.Refresh, Description: "Refresh the current table"},
 			Bind{Key: Key{Char: 'K'}, Cmd: cmd.SortAsc, Description: "Sort ascending"},
 			Bind{Key: Key{Char: 'C'}, Cmd: cmd.SetValue, Description: "Toggle value menu to put values like NULL, EMPTY or DEFAULT"},
 			// Tabs

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -42,6 +42,7 @@ const (
 	TabClose
 
 	// Operations
+	Refresh
 	UnfocusEditor
 	Copy
 	Edit

--- a/components/ResultsTable.go
+++ b/components/ResultsTable.go
@@ -326,7 +326,7 @@ func (table *ResultsTable) tableInputCapture(event *tcell.EventKey) *tcell.Event
 
 	command := app.Keymaps.Group(app.TableGroup).Resolve(event)
 
-	menuCommands := []commands.Command{commands.RecordsMenu, commands.ColumnsMenu, commands.ConstraintsMenu, commands.ForeignKeysMenu, commands.IndexesMenu}
+	menuCommands := []commands.Command{commands.RecordsMenu, commands.ColumnsMenu, commands.ConstraintsMenu, commands.ForeignKeysMenu, commands.IndexesMenu, commands.Refresh}
 
 	if helpers.ContainsCommand(menuCommands, command) {
 		table.Select(1, 0)
@@ -350,6 +350,14 @@ func (table *ResultsTable) tableInputCapture(event *tcell.EventKey) *tcell.Event
 		case commands.IndexesMenu:
 			table.Menu.SetSelectedOption(5)
 			table.UpdateRows(table.GetIndexes())
+		case commands.Refresh:
+			if table.Loading != nil {
+				app.App.SetFocus(table.Loading)
+			}
+			table.Menu.SetSelectedOption(1)
+			if err := table.FetchRecords(nil); err != nil {
+				return event
+			}
 		}
 	}
 


### PR DESCRIPTION
## [feat]: Refresh Current Table

### Description of Changes
This pull request introduces a new feature that allows users to refresh the current table view in the application.
The changes include:

- Added refresh func to fetch latest data.
- Updated UI for refreshed state.
- Reduced redundant database calls.

### Issue Ticket Number and Link
Closes [#97](https://github.com/jorgerojas26/lazysql/issues/97)

### Type of Change
- [X] New feature (non-breaking change that adds functionality)

### Additional Notes
- Please ensure to test the refresh feature thoroughly in different scenarios.
