### PR TITLE
Add connecting to database by connectionString given as an argument to cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,10 +132,14 @@ makepkg -si
 <!-- USAGE EXAMPLES -->
 
 ## Usage
-
 ```bash
 $ lazysql
 ```
+To launch lazysql with the ability to pick from the saved connections.
+```bash
+$ lazysql [connection_url]
+```
+To launch lazysql and connect to database at [connection_url].
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/README.md
+++ b/README.md
@@ -133,12 +133,12 @@ makepkg -si
 
 ## Usage
 
-```bash
+```console
 $ lazysql
 ```
 
 To launch lazysql with the ability to pick from the saved connections.
-```bash
+```console
 $ lazysql [connection_url]
 ```
 

--- a/README.md
+++ b/README.md
@@ -132,13 +132,16 @@ makepkg -si
 <!-- USAGE EXAMPLES -->
 
 ## Usage
+
 ```bash
 $ lazysql
 ```
+
 To launch lazysql with the ability to pick from the saved connections.
 ```bash
 $ lazysql [connection_url]
 ```
+
 To launch lazysql and connect to database at [connection_url].
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>

--- a/components/ArgConnection.go
+++ b/components/ArgConnection.go
@@ -1,8 +1,8 @@
 package components
 
 import (
+	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/jorgerojas26/lazysql/drivers"
@@ -10,11 +10,10 @@ import (
 	"github.com/jorgerojas26/lazysql/models"
 )
 
-func InitFromArg(connectionString string) {
+func InitFromArg(connectionString string) error {
 	parsed, err := helpers.ParseConnectionString(connectionString)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Could not parse connection string: %s\n", err)
-		os.Exit(1)
+		return errors.New(fmt.Sprintf("Could not parse connection string: %s", err))
 	}
 	DBName := strings.Split(parsed.Normalize(",", "NULL", 0), ",")[3]
 
@@ -40,8 +39,8 @@ func InitFromArg(connectionString string) {
 	err = newDbDriver.Connect(connection.URL)
 
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Could not connect to database %s: %s\n", connectionString, err)
-		os.Exit(1)
+		return errors.New(fmt.Sprintf("Could not connect to database %s: %s", connectionString, err))
 	}
 	MainPages.AddAndSwitchToPage(connection.URL, NewHomePage(connection, newDbDriver).Flex, true)
+	return nil
 }

--- a/components/ArgConnection.go
+++ b/components/ArgConnection.go
@@ -1,7 +1,6 @@
 package components
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -13,7 +12,7 @@ import (
 func InitFromArg(connectionString string) error {
 	parsed, err := helpers.ParseConnectionString(connectionString)
 	if err != nil {
-		return errors.New(fmt.Sprintf("Could not parse connection string: %s", err))
+		return fmt.Errorf("Could not parse connection string: %s", err)
 	}
 	DBName := strings.Split(parsed.Normalize(",", "NULL", 0), ",")[3]
 
@@ -39,7 +38,7 @@ func InitFromArg(connectionString string) error {
 	err = newDbDriver.Connect(connection.URL)
 
 	if err != nil {
-		return errors.New(fmt.Sprintf("Could not connect to database %s: %s", connectionString, err))
+		return fmt.Errorf("Could not connect to database %s: %s", connectionString, err)
 	}
 	MainPages.AddAndSwitchToPage(connection.URL, NewHomePage(connection, newDbDriver).Flex, true)
 	return nil

--- a/components/ArgConnection.go
+++ b/components/ArgConnection.go
@@ -3,6 +3,7 @@ package components
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/jorgerojas26/lazysql/drivers"
 	"github.com/jorgerojas26/lazysql/helpers"
@@ -12,13 +13,19 @@ import (
 func InitFromArg(connectionString string) {
 	parsed, err := helpers.ParseConnectionString(connectionString)
 	if err != nil {
-		fmt.Printf("Could not parse connection string: %s\n", err)
+		fmt.Fprintf(os.Stderr, "Could not parse connection string: %s\n", err)
 		os.Exit(1)
 	}
+	DBName := strings.Split(parsed.Normalize(",", "NULL", 0), ",")[3]
+
+	if DBName == "NULL" {
+		DBName = ""
+	}
+
 	connection := models.Connection{
-		Name:     connectionString,
+		Name:     "",
 		Provider: parsed.Driver,
-		DBName:   connectionString,
+		DBName:   DBName,
 		URL:      connectionString,
 	}
 	var newDbDriver drivers.Driver
@@ -33,8 +40,8 @@ func InitFromArg(connectionString string) {
 	err = newDbDriver.Connect(connection.URL)
 
 	if err != nil {
-		fmt.Printf("Could not connect to database %s: %s\n", connectionString, err)
+		fmt.Fprintf(os.Stderr, "Could not connect to database %s: %s\n", connectionString, err)
 		os.Exit(1)
 	}
-	MainPages.AddPage(connection.URL, NewHomePage(connection, newDbDriver).Flex, true, true)
+	MainPages.AddAndSwitchToPage(connection.URL, NewHomePage(connection, newDbDriver).Flex, true)
 }

--- a/components/ArgConnection.go
+++ b/components/ArgConnection.go
@@ -1,0 +1,40 @@
+package components
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/jorgerojas26/lazysql/drivers"
+	"github.com/jorgerojas26/lazysql/helpers"
+	"github.com/jorgerojas26/lazysql/models"
+)
+
+func InitFromArg(connectionString string) {
+	parsed, err := helpers.ParseConnectionString(connectionString)
+	if err != nil {
+		fmt.Printf("Could not parse connection string: %s\n", err)
+		os.Exit(1)
+	}
+	connection := models.Connection{
+		Name:     connectionString,
+		Provider: parsed.Driver,
+		DBName:   connectionString,
+		URL:      connectionString,
+	}
+	var newDbDriver drivers.Driver
+	switch connection.Provider {
+	case drivers.DriverMySQL:
+		newDbDriver = &drivers.MySQL{}
+	case drivers.DriverPostgres:
+		newDbDriver = &drivers.Postgres{}
+	case drivers.DriverSqlite:
+		newDbDriver = &drivers.SQLite{}
+	}
+	err = newDbDriver.Connect(connection.URL)
+
+	if err != nil {
+		fmt.Printf("Could not connect to database %s: %s\n", connectionString, err)
+		os.Exit(1)
+	}
+	MainPages.AddPage(connection.URL, NewHomePage(connection, newDbDriver).Flex, true, true)
+}

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"flag"
-	"fmt"
 	"io"
 	"log"
 	"os"
@@ -11,10 +10,7 @@ import (
 
 	"github.com/jorgerojas26/lazysql/app"
 	"github.com/jorgerojas26/lazysql/components"
-	"github.com/jorgerojas26/lazysql/drivers"
-	"github.com/jorgerojas26/lazysql/helpers"
 	"github.com/jorgerojas26/lazysql/helpers/logger"
-	"github.com/jorgerojas26/lazysql/models"
 )
 
 var version = "dev"
@@ -50,25 +46,7 @@ func main() {
 			fmt.Println("LazySQL version: ", version)
 			os.Exit(0)
 		default:
-			connectionString := argsWithProg[1]
-			parsed, err := helpers.ParseConnectionString(connectionString)
-			if err != nil {
-				fmt.Printf("Could not parse connection string: %s\n", err)
-				os.Exit(1)
-			}
-			connection := models.Connection{
-				Name:     connectionString,
-				Provider: parsed.Driver,
-				DBName:   connectionString,
-				URL:      connectionString,
-			}
-			newDbDriver := &drivers.SQLite{}
-			err = newDbDriver.Connect(connection.URL)
-			if err != nil {
-				fmt.Printf("Could not connect to database %s: %s\n", connectionString, err)
-				os.Exit(1)
-			}
-			components.MainPages.AddPage(connection.URL, components.NewHomePage(connection, newDbDriver).Flex, true, true)
+			components.InitFromArg(argsWithProg[1])
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ func main() {
 
 	// Check if "version" arg is passed.
 	argsWithProg := os.Args
+
 	if len(argsWithProg) > 1 {
 		switch argsWithProg[1] {
 		case "version":

--- a/main.go
+++ b/main.go
@@ -64,12 +64,10 @@ func main() {
 	case 1:
 		err := components.InitFromArg(args[0])
 		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
+			log.Fatal(err)
 		}
 	default:
-		fmt.Fprintln(os.Stderr, "Only a single connection is allowed")
-		os.Exit(1)
+		log.Fatal("Only a single connection is allowed")
 	}
 
 	if err = app.App.Run(components.MainPages); err != nil {

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"io"
 	"log"
 	"os"
@@ -46,7 +47,11 @@ func main() {
 			fmt.Println("LazySQL version: ", version)
 			os.Exit(0)
 		default:
-			components.InitFromArg(argsWithProg[1])
+			err := components.InitFromArg(argsWithProg[1])
+			if err != nil {
+				fmt.Println(os.Stderr, err) 
+				os.Exit(1)
+			}
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -8,10 +8,12 @@ import (
 	"os"
 
 	"github.com/go-sql-driver/mysql"
-
 	"github.com/jorgerojas26/lazysql/app"
 	"github.com/jorgerojas26/lazysql/components"
+	"github.com/jorgerojas26/lazysql/drivers"
+	"github.com/jorgerojas26/lazysql/helpers"
 	"github.com/jorgerojas26/lazysql/helpers/logger"
+	"github.com/jorgerojas26/lazysql/models"
 )
 
 var version = "dev"
@@ -41,12 +43,31 @@ func main() {
 
 	// Check if "version" arg is passed.
 	argsWithProg := os.Args
-
 	if len(argsWithProg) > 1 {
 		switch argsWithProg[1] {
 		case "version":
 			fmt.Println("LazySQL version: ", version)
 			os.Exit(0)
+		default:
+			connectionString := argsWithProg[1]
+			parsed, err := helpers.ParseConnectionString(connectionString)
+			if err != nil {
+				fmt.Printf("Could not parse connection string: %s\n", err)
+				os.Exit(1)
+			}
+			connection := models.Connection{
+				Name:     connectionString,
+				Provider: parsed.Driver,
+				DBName:   connectionString,
+				URL:      connectionString,
+			}
+			newDbDriver := &drivers.SQLite{}
+			err = newDbDriver.Connect(connection.URL)
+			if err != nil {
+				fmt.Printf("Could not connect to database %s: %s\n", connectionString, err)
+				os.Exit(1)
+			}
+			components.MainPages.AddPage(connection.URL, components.NewHomePage(connection, newDbDriver).Flex, true, true)
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -17,9 +17,26 @@ import (
 var version = "dev"
 
 func main() {
+	flag.Usage = func() {
+		f := flag.CommandLine.Output()
+		fmt.Fprintln(f, "lazysql")
+		fmt.Fprintln(f, "")
+		fmt.Fprintf(f, "Usage:  %s [options] [connection_url]\n\n", os.Args[0])
+		fmt.Fprintln(f, "  connection_url")
+		fmt.Fprintln(f, "        database URL to connect to. Omit to start in picker mode")
+		fmt.Fprintln(f, "")
+		fmt.Fprintln(f, "Options:")
+		flag.PrintDefaults()
+	}
+	printVersion := flag.Bool("version", false, "Show version")
 	logLevel := flag.String("loglevel", "info", "Log level")
 	logFile := flag.String("logfile", "", "Log file")
 	flag.Parse()
+
+	if *printVersion {
+		println("LazySQL version: ", version)
+		os.Exit(0)
+	}
 
 	slogLevel, err := logger.ParseLogLevel(*logLevel)
 	if err != nil {
@@ -39,20 +56,16 @@ func main() {
 		log.Fatalf("Error setting MySQL logger: %v", err)
 	}
 
-	// Check if "version" arg is passed.
-	argsWithProg := os.Args
+	args := flag.Args()
 
-	if len(argsWithProg) > 1 {
-		switch argsWithProg[1] {
-		case "version":
-			fmt.Println("LazySQL version: ", version)
-			os.Exit(0)
-		default:
-			err := components.InitFromArg(argsWithProg[1])
-			if err != nil {
-				fmt.Fprintln(os.Stderr, err) 
-				os.Exit(1)
-			}
+	if len(args) > 1 {
+		fmt.Fprintln(os.Stderr, "Only a single connection is allowed")
+		os.Exit(1)
+	} else if len(args) == 1 {
+		err := components.InitFromArg(args[0])
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			os.Exit(1)
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -58,15 +58,18 @@ func main() {
 
 	args := flag.Args()
 
-	if len(args) > 1 {
-		fmt.Fprintln(os.Stderr, "Only a single connection is allowed")
-		os.Exit(1)
-	} else if len(args) == 1 {
+	switch len(args) {
+	case 0:
+		// nothing to do. Launch into the connection picker.
+	case 1:
 		err := components.InitFromArg(args[0])
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)
 		}
+	default:
+		fmt.Fprintln(os.Stderr, "Only a single connection is allowed")
+		os.Exit(1)
 	}
 
 	if err = app.App.Run(components.MainPages); err != nil {

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/go-sql-driver/mysql"
+
 	"github.com/jorgerojas26/lazysql/app"
 	"github.com/jorgerojas26/lazysql/components"
 	"github.com/jorgerojas26/lazysql/drivers"

--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ func main() {
 		default:
 			err := components.InitFromArg(argsWithProg[1])
 			if err != nil {
-				fmt.Println(os.Stderr, err) 
+				fmt.Fprintln(os.Stderr, err) 
 				os.Exit(1)
 			}
 		}


### PR DESCRIPTION
Thanks for the amazing tool! 
I'd like to see a feature like this get merged as I find it easier to just pass the path to the database I want to open as an argument, so I made this request. This implementation works but perhaps is doing a bit too much in the main.go file. I first tried doing most of this connection initialization inside Pages.go but the init() functions run before main.go's main() function.

I'd love to hear your feedback on this!