### PR TITLE
FEAT: Improve behavior of search `/` function on tree

### DIFF
--- a/components/Tree.go
+++ b/components/Tree.go
@@ -326,28 +326,33 @@ func (tree *Tree) databasesToNodes(children map[string][]string, node *tview.Tre
 
 func (tree *Tree) search(searchText string) {
 	rootNode := tree.GetRoot()
+	currNode := tree.GetCurrentNode()
 	lowerSearchText := strings.ToLower(searchText)
 	tree.state.searchFoundNodes = []*tview.TreeNode{}
 
 	if lowerSearchText == "" {
 		rootNode.Walk(func(_, parent *tview.TreeNode) bool {
 			if parent != nil && parent != rootNode && parent.IsExpanded() {
-				parent.SetExpanded(false)
+				parent.SetExpanded(true)
 			}
 			return true
 		})
 		return
 	}
 
-	// filteredNodes := make([]*TreeStateNode, 0, len(treeNodes))
+	var searchStartNode *tview.TreeNode
+	if currNode != nil && currNode.IsExpanded() {
+		// search between tables if theres a curentdatabase selected
+		searchStartNode = currNode
+	} else {
+		// if there's no current database selected, search within the database names only
+		searchStartNode = rootNode
+	}
 
-	rootNode.Walk(func(node, parent *tview.TreeNode) bool {
+	searchStartNode.Walk(func(node, parent *tview.TreeNode) bool {
 		nodeText := strings.ToLower(node.GetText())
 
 		if strings.Contains(nodeText, lowerSearchText) {
-			if parent != nil {
-				parent.SetExpanded(true)
-			}
 			tree.state.searchFoundNodes = append(tree.state.searchFoundNodes, node)
 			tree.SetCurrentNode(node)
 			tree.state.currentFocusFoundNode = node

--- a/components/Tree.go
+++ b/components/Tree.go
@@ -333,7 +333,7 @@ func (tree *Tree) search(searchText string) {
 	if lowerSearchText == "" {
 		rootNode.Walk(func(_, parent *tview.TreeNode) bool {
 			if parent != nil && parent != rootNode && parent.IsExpanded() {
-				parent.SetExpanded(true)
+				parent.SetExpanded(false)
 			}
 			return true
 		})


### PR DESCRIPTION
- Closes #121

# Current Behavior
Running the search command `/` will expand all databases and find all possibilities of tables within the whole server, throughout all databases.

The issue arises when there are multple instances of table names within multiple databases. it becomes hard to determine which database the focused table is from since the database is expanded, and if there are 20+ tables you cannot see the DB name unless you move up. 

# Implemented Behavior
To mark a database as "selected" It has to be the `currNode` and it should be expanded. 

- If there is no database selected. The search function will search throughout the names of all the databases ONLY.
- If there is a database selected. The search function will search thorughout the names of all the tables within the selected database.

I believe this is a better implementation since its most common to search a table within a specific database, rather than all the databases. 

I can also include in this PR to move the command that "searches on all databases" to `CTRL + /`. 