### PR TITLE
Make the active button stand out in more terminal themes

### DIFF
--- a/components/ConfirmationModal.go
+++ b/components/ConfirmationModal.go
@@ -1,6 +1,7 @@
 package components
 
 import (
+	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 
 	"github.com/jorgerojas26/lazysql/app"
@@ -19,6 +20,10 @@ func NewConfirmationModal(confirmationText string) *ConfirmationModal {
 	}
 	modal.AddButtons([]string{"Yes", "No"})
 	modal.SetBackgroundColor(app.Styles.PrimitiveBackgroundColor)
+	modal.SetButtonActivatedStyle(tcell.StyleDefault.
+		Background(app.Styles.InverseTextColor).
+		Foreground(app.Styles.ContrastSecondaryTextColor),
+	)
 	modal.SetTextColor(app.Styles.PrimaryTextColor)
 
 	return &ConfirmationModal{


### PR DESCRIPTION
At least in my terminal I was not able to see the active button so choosing `yes` or `no` felt like a gamble 😉 