### PR TITLE
Do not try to recover from panics, but use the return values

### DIFF
--- a/components/ResultsTable.go
+++ b/components/ResultsTable.go
@@ -812,23 +812,11 @@ func (table *ResultsTable) SetResultsInfo(text string) {
 }
 
 func (table *ResultsTable) SetLoading(show bool) {
-	defer func() {
-		if r := recover(); r != nil {
-			logger.Error("ResultsTable.go:800 => Recovered from panic", map[string]any{"error": r})
-			_ = table.Page.HidePage(pageNameTableLoading)
-			if table.state.error != "" {
-				App.SetFocus(table.Error)
-			} else {
-				App.SetFocus(table)
-			}
-		}
-	}()
-
 	table.state.isLoading = show
+
 	if show {
 		table.Page.ShowPage(pageNameTableLoading)
 		App.SetFocus(table.Loading)
-		App.ForceDraw()
 	} else {
 		table.Page.HidePage(pageNameTableLoading)
 		if table.state.error != "" {
@@ -836,8 +824,9 @@ func (table *ResultsTable) SetLoading(show bool) {
 		} else {
 			App.SetFocus(table)
 		}
-		App.ForceDraw()
 	}
+
+	App.ForceDraw()
 }
 
 func (table *ResultsTable) SetIsEditing(editing bool) {

--- a/drivers/postgres.go
+++ b/drivers/postgres.go
@@ -98,13 +98,13 @@ func (db *Postgres) GetTables(database string) (tables map[string][]string, err 
 		if err != nil {
 			return nil, err
 		}
-	}
 
-	defer func() {
-		if r := recover(); r != nil {
-			_ = db.SwitchDatabase(db.PreviousDatabase)
-		}
-	}()
+		defer func() {
+			if err != nil {
+				_ = db.SwitchDatabase(db.PreviousDatabase)
+			}
+		}()
+	}
 
 	query := "SELECT table_name, table_schema FROM information_schema.tables WHERE table_catalog = $1"
 	rows, err := db.Connection.Query(query, database)
@@ -151,13 +151,13 @@ func (db *Postgres) GetTableColumns(database, table string) (results [][]string,
 		if err != nil {
 			return nil, err
 		}
-	}
 
-	defer func() {
-		if r := recover(); r != nil {
-			_ = db.SwitchDatabase(db.PreviousDatabase)
-		}
-	}()
+		defer func() {
+			if err != nil {
+				_ = db.SwitchDatabase(db.PreviousDatabase)
+			}
+		}()
+	}
 
 	tableSchema := splitTableString[0]
 	tableName := splitTableString[1]
@@ -223,13 +223,13 @@ func (db *Postgres) GetConstraints(database, table string) (constraints [][]stri
 		if err != nil {
 			return nil, err
 		}
-	}
 
-	defer func() {
-		if r := recover(); r != nil {
-			_ = db.SwitchDatabase(db.PreviousDatabase)
-		}
-	}()
+		defer func() {
+			if err != nil {
+				_ = db.SwitchDatabase(db.PreviousDatabase)
+			}
+		}()
+	}
 
 	tableSchema := splitTableString[0]
 	tableName := splitTableString[1]
@@ -306,13 +306,13 @@ func (db *Postgres) GetForeignKeys(database, table string) (foreignKeys [][]stri
 		if err != nil {
 			return nil, err
 		}
-	}
 
-	defer func() {
-		if r := recover(); r != nil {
-			_ = db.SwitchDatabase(db.PreviousDatabase)
-		}
-	}()
+		defer func() {
+			if err != nil {
+				_ = db.SwitchDatabase(db.PreviousDatabase)
+			}
+		}()
+	}
 
 	tableSchema := splitTableString[0]
 	tableName := splitTableString[1]
@@ -390,13 +390,13 @@ func (db *Postgres) GetIndexes(database, table string) (indexes [][]string, err 
 		if err != nil {
 			return nil, err
 		}
-	}
 
-	defer func() {
-		if r := recover(); r != nil {
-			_ = db.SwitchDatabase(db.PreviousDatabase)
-		}
-	}()
+		defer func() {
+			if err != nil {
+				_ = db.SwitchDatabase(db.PreviousDatabase)
+			}
+		}()
+	}
 
 	tableSchema := splitTableString[0]
 	tableName := splitTableString[1]
@@ -483,15 +483,13 @@ func (db *Postgres) GetRecords(database, table, where, sort string, offset, limi
 		if err != nil {
 			return nil, 0, err
 		}
-	}
 
-	defer func() {
-		if r := recover(); r != nil {
-			if database != db.PreviousDatabase {
+		defer func() {
+			if err != nil {
 				_ = db.SwitchDatabase(db.PreviousDatabase)
 			}
-		}
-	}()
+		}()
+	}
 
 	tableSchema := splitTableString[0]
 	tableName := splitTableString[1]
@@ -872,13 +870,13 @@ func (db *Postgres) GetPrimaryKeyColumnNames(database, table string) (primaryKey
 		if err != nil {
 			return nil, err
 		}
-	}
 
-	defer func() {
-		if r := recover(); r != nil {
-			_ = db.SwitchDatabase(db.PreviousDatabase)
-		}
-	}()
+		defer func() {
+			if err != nil {
+				_ = db.SwitchDatabase(db.PreviousDatabase)
+			}
+		}()
+	}
 
 	tableName := splitTableString[1]
 


### PR DESCRIPTION
Sorry for all the PRs, I'm just having fun with it and am hitting a lot of small issues when using `lazysql` which I would like to help improve 😉 

This PR removes all the calls to `recover` as it is very discouraged (see Go docs) to try and recover panics as in in 99.999999% of the cases that indicates a bug in the program or another error not being handled properly which should be fixed instead.

In order to take any actions using a `defer` that will only do something if the function returned an error, its best to just check against that error. While in Go its no too common to use named return values in the function signature, in the case where you want a defer to have access to the actual returned value I found it to be the most robust to at least name the error in the function signature. But in this case I noticed you already named _all_ return values so I didn't need to change anything for that.