### PR TITLE
Use the "real" offset to calculate the currently shown records

### DIFF
--- a/components/pagination.go
+++ b/components/pagination.go
@@ -70,7 +70,7 @@ func (pagination *Pagination) SetTotalRecords(total int) {
 		offset++
 	}
 
-	limit := pagination.GetLimit() + offset
+	limit := pagination.GetLimit() + pagination.GetOffset()
 	if limit > total {
 		limit = total
 	}


### PR DESCRIPTION
The local offset variable is increased by 1 so the records start at 1 instead of at 0. But that should not be taken into account when calculating the record number of the last fetched record...