### PR TITLE
Update the pagination logic for queries done from the SQL editor

### DIFF
--- a/components/pagination.go
+++ b/components/pagination.go
@@ -66,11 +66,11 @@ func (pagination *Pagination) SetTotalRecords(total int) {
 	pagination.state.TotalRecords = total
 
 	offset := pagination.GetOffset()
+	limit := pagination.GetLimit() + offset
+
 	if offset < total {
 		offset++
 	}
-
-	limit := pagination.GetLimit() + pagination.GetOffset()
 	if limit > total {
 		limit = total
 	}
@@ -84,11 +84,14 @@ func (pagination *Pagination) SetLimit(limit int) {
 	offset := pagination.GetOffset()
 	total := pagination.GetTotalRecords()
 
+	if offset < total {
+		offset++
+	}
 	if limit > total {
 		limit = total
 	}
 
-	pagination.textView.SetText(fmt.Sprintf("%d-%d of %d rows", offset+1, limit, total))
+	pagination.textView.SetText(fmt.Sprintf("%d-%d of %d rows", offset, limit, total))
 }
 
 func (pagination *Pagination) SetOffset(offset int) {
@@ -97,9 +100,12 @@ func (pagination *Pagination) SetOffset(offset int) {
 	limit := pagination.GetLimit() + offset
 	total := pagination.GetTotalRecords()
 
+	if offset < total {
+		offset++
+	}
 	if limit > total {
 		limit = total
 	}
 
-	pagination.textView.SetText(fmt.Sprintf("%d-%d of %d rows", offset+1, limit, total))
+	pagination.textView.SetText(fmt.Sprintf("%d-%d of %d rows", offset, limit, total))
 }

--- a/components/results_table.go
+++ b/components/results_table.go
@@ -615,30 +615,19 @@ func (table *ResultsTable) subscribeToEditorChanges() {
 
 					if err != nil {
 						table.SetLoading(false)
-						App.Draw()
 						table.SetError(err.Error(), nil)
+						App.Draw()
 					} else {
 						table.UpdateRows(rows)
-						table.SetIsFiltering(false)
-
-						if len(rows) > 1 {
-							App.SetFocus(table)
-							table.HighlightTable()
-							table.Editor.SetBlur()
-							table.SetInputCapture(table.tableInputCapture)
-							App.Draw()
-						} else if len(rows) == 1 {
-							table.SetInputCapture(nil)
-							App.SetFocus(table.Editor)
-							table.Editor.Highlight()
-							table.RemoveHighlightTable()
-							table.SetIsFiltering(true)
-							App.Draw()
-						}
 						table.SetLoading(false)
+						table.SetIsFiltering(false)
+						table.HighlightTable()
+						table.Editor.SetBlur()
+						table.SetInputCapture(table.tableInputCapture)
+						table.EditorPages.SwitchToPage(pageNameTableEditorTable)
+						App.SetFocus(table)
+						App.Draw()
 					}
-					table.EditorPages.SwitchToPage(pageNameTableEditorTable)
-					App.Draw()
 				} else {
 					table.SetRecords([][]string{})
 					table.SetLoading(true)

--- a/components/results_table.go
+++ b/components/results_table.go
@@ -609,9 +609,9 @@ func (table *ResultsTable) subscribeToEditorChanges() {
 					table.SetLoading(true)
 					App.Draw()
 
-					rows, err := table.DBDriver.ExecuteQuery(query)
-					table.Pagination.SetTotalRecords(len(rows))
-					table.Pagination.SetLimit(len(rows))
+					rows, records, err := table.DBDriver.ExecuteQuery(query)
+					table.Pagination.SetTotalRecords(records)
+					table.Pagination.SetLimit(records)
 
 					if err != nil {
 						table.SetLoading(false)

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -17,9 +17,12 @@ type Driver interface {
 	UpdateRecord(database, table, column, value, primaryKeyColumnName, primaryKeyValue string) error
 	DeleteRecord(database, table string, primaryKeyColumnName, primaryKeyValue string) error
 	ExecuteDMLStatement(query string) (string, error)
-	ExecuteQuery(query string) ([][]string, error)
+	ExecuteQuery(query string) ([][]string, int, error)
 	ExecutePendingChanges(changes []models.DBDMLChange) error
-	SetProvider(provider string) // NOTE: This is used to get the primary key from the database table until i find a better way to do it. See ResultsTable.go GetPrimaryKeyValue function
 	GetProvider() string
 	GetPrimaryKeyColumnNames(database, table string) ([]string, error)
+
+	// NOTE: This is used to get the primary key from the database table until I
+	// find a better way to do it. See *ResultsTable.GetPrimaryKeyValue()
+	SetProvider(provider string)
 }


### PR DESCRIPTION
They previously didn't take the row with column names into account and I noticed there are actually 3 slightly different methods that calculate the pagination info, while I previously just updated/fixed one of them

The second commit changes the way how the SQL editor behaves a little as I continuously found myself doing the wrong thing here because the behavior was different depending on the result. If there were results the focus would switch to the table, if not it would stay with the editor.

While I understand that in some flows that makes sense as you might want to update your query and try again, but in a lot of other flows you might want to return to the tree or open another DB or...

So I thought it would easier for peoples' muscle memory to learn one consistent flow instead of having to think in between if there was output and if I should do different. For me the flow `Ctrl-E -> write or update query -> Ctrl-R` is really easy, consistent and never gives unexpected behavior.

But all that being said, let me know if you want me to drop the last commit. Thanks!