### PR TITLE
Partial fix to delete row funcionality

### DIFF
--- a/components/results_table.go
+++ b/components/results_table.go
@@ -346,6 +346,7 @@ func (table *ResultsTable) tableInputCapture(event *tcell.EventKey) *tcell.Event
 		case commands.RecordsMenu:
 			table.Menu.SetSelectedOption(1)
 			table.UpdateRows(table.GetRecords())
+			table.colorChangedCells()
 			table.AddInsertedRows()
 		case commands.ColumnsMenu:
 			table.Menu.SetSelectedOption(2)
@@ -744,6 +745,7 @@ func (table *ResultsTable) GetPrimaryKeyColumnNames() []string {
 func (table *ResultsTable) SetRecords(rows [][]string) {
 	table.state.records = rows
 	table.UpdateRows(rows)
+	table.colorChangedCells()
 }
 
 func (table *ResultsTable) SetColumns(columns [][]string) {
@@ -1389,4 +1391,17 @@ func (table *ResultsTable) isAnInsertedRow(rowIndex int) (isAnInsertedRow bool, 
 
 	}
 	return false, -1
+}
+
+func (table *ResultsTable) colorChangedCells() {
+	for _, dmlChange := range *table.state.listOfDBChanges {
+		switch dmlChange.Type {
+		case models.DMLDeleteType:
+			table.SetRowColor(dmlChange.Values[0].TableRowIndex, colorTableDelete)
+		case models.DMLUpdateType:
+			for _, value := range dmlChange.Values {
+				table.SetCellColor(value.TableRowIndex, value.TableColumnIndex, colorTableChange)
+			}
+		}
+	}
 }

--- a/components/results_table.go
+++ b/components/results_table.go
@@ -439,6 +439,7 @@ func (table *ResultsTable) tableInputCapture(event *tcell.EventKey) *tcell.Event
 				}
 			} else {
 				table.AppendNewChange(models.DMLDeleteType, selectedRowIndex, -1, models.CellValue{})
+				table.AppendNewChange(models.DMLDeleteType, selectedRowIndex, -1, models.CellValue{TableColumnIndex: -1, TableRowIndex: selectedRowIndex})
 			}
 
 		}


### PR DESCRIPTION
This is a partial fix to be able to mark and unmark rows to be deleted and keep row coloring.

But i am aware there are a lot of problems to keep the state of the changes being made to the rows (update, delete, append).

I will make a huge revamp to that logic in another PR.

Fixes #153 