### PR TITLE
Command for Refresh external file and execute query (F2)

### DIFF
--- a/app/keymap.go
+++ b/app/keymap.go
@@ -124,6 +124,7 @@ var Keymaps = KeymapSystem{
 			Bind{Key: Key{Code: tcell.KeyCtrlR}, Cmd: cmd.Execute, Description: "Execute query"},
 			Bind{Key: Key{Code: tcell.KeyEscape}, Cmd: cmd.UnfocusEditor, Description: "Unfocus editor"},
 			Bind{Key: Key{Code: tcell.KeyCtrlSpace}, Cmd: cmd.OpenInExternalEditor, Description: "Open in external editor"},
+			Bind{Key: Key{Code: tcell.KeyF2}, Cmd: cmd.RefreshExternalFile, Description: "Refresh external file and execute query"},
 		},
 		SidebarGroup: {
 			Bind{Key: Key{Char: 's'}, Cmd: cmd.UnfocusSidebar, Description: "Focus table"},

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -54,6 +54,7 @@ const (
 	Quit
 	Execute
 	OpenInExternalEditor
+	RefreshExternalFile
 	AppendNewRow
 	SortAsc
 	SortDesc
@@ -146,6 +147,8 @@ func (c Command) String() string {
 		return "Execute"
 	case OpenInExternalEditor:
 		return "OpenInExternalEditor"
+	case RefreshExternalFile:
+		return "RefreshExternalFile"
 	case AppendNewRow:
 		return "AppendNewRow"
 	case SortAsc:

--- a/components/sql_editor.go
+++ b/components/sql_editor.go
@@ -51,6 +51,11 @@ func NewSQLEditor() *SQLEditor {
 				text := openExternalEditor(sqlEditor)
 				sqlEditor.SetText(text, true)
 			}
+		case commands.RefreshExternalFile:
+
+			text := refreshExternalFile(sqlEditor)
+			sqlEditor.SetText(text, true)
+			sqlEditor.Publish(eventSQLEditorQuery, sqlEditor.GetText())
 		}
 
 		return event
@@ -90,6 +95,23 @@ func (s *SQLEditor) Highlight() {
 func (s *SQLEditor) SetBlur() {
 	s.SetBorderColor(app.Styles.InverseTextColor)
 	s.SetTextStyle(tcell.StyleDefault.Foreground(app.Styles.InverseTextColor))
+}
+
+/*
+Function to refresh the external temporary file (lazysql.sql) from the CWD and load it to the SQLEditor instance
+TODO: ability to pass the name of the file to load.
+*/
+func refreshExternalFile(s *SQLEditor) string {
+
+	// Current folder as path of temporary file
+	path := "./lazysql.sql"
+
+	updatedContent, err := os.ReadFile(path)
+
+	if err != nil {
+		return s.GetText()
+	}
+	return string(updatedContent)
 }
 
 /*


### PR DESCRIPTION
adding functionality to reload the external file (lazysql.sql) and excute the query with F2

Main purpose:

With external editor functionality, the posibilities are endless, 

what I do is open Helix in a separate pane 
![image](https://github.com/user-attachments/assets/83410bdb-a759-4534-b9a1-ab4924295ec0)

Then type the query in helix using sql server language tied to my database and with autocomplete and highlighting (really nice) then press F2 from Helix, that triggers saving the lazysql.sql file, then sends the characters to lazysql (using zellij cli actions) to reload and executes the query on lazysql.

![image](https://github.com/user-attachments/assets/99c2d894-8199-4eba-b757-efab77351416)

This could be a really nice integration so you dont need to write a whole SQL editor. 