### PR TITLE
feat: add offset layout to the sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ URL = 'postgres://postgres:urlencodedpassword@localhost:5432/foo'
 [application]
 DefaultPageSize = 300
 DisableSidebar = false
+SidebarOverlay = false
 ```
 
 The `[aplication]` section is used to define some app settings. Not all settings are available yet, this is a work in progress.

--- a/app/config.go
+++ b/app/config.go
@@ -21,6 +21,7 @@ func defaultConfig() *Config {
 	return &Config{
 		AppConfig: &models.AppConfig{
 			DefaultPageSize: 300,
+			SidebarOverlay:  false,
 		},
 	}
 }

--- a/components/results_table.go
+++ b/components/results_table.go
@@ -110,7 +110,7 @@ func NewResultsTable(listOfDBChanges *[]models.DBDMLChange, tree *Tree, dbdriver
 	}
 
 	// When AppConfig.SidebarOverlay is true, the sidebar is added as a page to the table.Page.
-	// When AppConfig.SidebarOverlay is false, the sidebar is added as a page to the table.SidebarContainer.
+	// When AppConfig.SidebarOverlay is false, the sidebar is added to the table.SidebarContainer.
 	table.Page.AddPage(pageNameSidebar, table.Sidebar, false, false)
 
 	table.SetSelectable(true, true)

--- a/components/results_table.go
+++ b/components/results_table.go
@@ -119,7 +119,7 @@ func NewResultsTable(listOfDBChanges *[]models.DBDMLChange, tree *Tree, dbdriver
 	table.SetInputCapture(table.tableInputCapture)
 	table.SetSelectedStyle(tcell.StyleDefault.Background(app.Styles.SecondaryTextColor).Foreground(tview.Styles.ContrastSecondaryTextColor))
 
-	table.SetSelectionChangedFunc(func(row, col int) {
+	table.SetSelectionChangedFunc(func(_, _ int) {
 		if table.GetShowSidebar() {
 			go table.UpdateSidebar()
 		}

--- a/models/models.go
+++ b/models/models.go
@@ -7,6 +7,7 @@ import (
 type AppConfig struct {
 	DefaultPageSize int
 	DisableSidebar  bool
+	SidebarOverlay  bool
 }
 
 type Connection struct {


### PR DESCRIPTION
The main idea of this PR is to add an offset layout to the sidebar, so users can choose between offset and overlay layout as they want with the new `SidebarOverlay` config option.

Also, the default value for `SidebarOverlay` is false, so the offset layout is the default now.

Offset layout:
![image](https://github.com/user-attachments/assets/da4553ba-2f74-4e50-a380-4ba1a6be2d5d)

Overlay layout:
![image](https://github.com/user-attachments/assets/8bb3598a-e9c1-4537-ad94-9ca59c6ac139)

Fixes #160