### PR TITLE
feat: add search pattern dbName + tableName

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -160,8 +160,7 @@ linters-settings:
   dupword:
     # Keywords used to ignore detection.
     # Default: []
-    ignore:
-    #  - "blah" # this will accept "blah blah …" as a valid duplicate word
+    ignore: []
 
   gosec:
     # To specify a set of rules to explicitly exclude.
@@ -178,11 +177,8 @@ linters-settings:
 
     # List of words to ignore
     # among the one defined in https://github.com/golangci/misspell/blob/master/words.go
-    ignore-words:
-    #  - valor
-    #  - and
+    ignore-words: []
 
     # Extra word corrections.
-    extra-words:
-    #  - typo: "whattever"
-    #    correction: "whatever"
+    extra-words: []
+

--- a/components/tree.go
+++ b/components/tree.go
@@ -203,24 +203,8 @@ func NewTree(dbName string, dbdriver drivers.Driver) *Tree {
 		App.SetFocus(tree)
 	})
 
-	tree.Filter.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
-		if event.Key() != tcell.KeyEscape && event.Key() != tcell.KeyEnter {
-			isBackSpace := event.Key() == tcell.KeyBackspace2
-
-			filterText := tree.Filter.GetText()
-
-			if isBackSpace {
-				if len(filterText) > 0 {
-					tree.search(filterText[:len(filterText)-1])
-				} else {
-					tree.search("")
-				}
-			} else {
-				tree.search(filterText + string(event.Rune()))
-			}
-		}
-
-		return event
+	tree.Filter.SetChangedFunc(func(text string) {
+		go tree.search(text)
 	})
 
 	tree.Filter.SetFieldStyle(tcell.StyleDefault.Background(app.Styles.PrimitiveBackgroundColor).Foreground(tview.Styles.PrimaryTextColor))
@@ -355,8 +339,6 @@ func (tree *Tree) search(searchText string) {
 
 		return true
 	})
-
-	App.ForceDraw()
 }
 
 // Subscribe to changes in the tree state

--- a/components/tree.go
+++ b/components/tree.go
@@ -318,18 +318,39 @@ func (tree *Tree) search(searchText string) {
 		return
 	}
 
-	// filteredNodes := make([]*TreeStateNode, 0, len(treeNodes))
+	parts := strings.SplitN(lowerSearchText, " ", 2)
+	databaseNameFilter := ""
+	tableNameFilter := ""
+
+	if len(parts) == 1 {
+		tableNameFilter = parts[0]
+	} else {
+		databaseNameFilter = parts[0]
+		tableNameFilter = parts[1]
+	}
 
 	rootNode.Walk(func(node, parent *tview.TreeNode) bool {
 		nodeText := strings.ToLower(node.GetText())
 
-		if fuzzy.Match(lowerSearchText, nodeText) {
-			if parent != nil {
-				parent.SetExpanded(true)
+		if databaseNameFilter == "" {
+			if fuzzy.Match(tableNameFilter, nodeText) {
+				if parent != nil {
+					parent.SetExpanded(true)
+				}
+				tree.state.searchFoundNodes = append(tree.state.searchFoundNodes, node)
+				tree.SetCurrentNode(node)
+				tree.state.currentFocusFoundNode = node
 			}
-			tree.state.searchFoundNodes = append(tree.state.searchFoundNodes, node)
-			tree.SetCurrentNode(node)
-			tree.state.currentFocusFoundNode = node
+		} else {
+			if fuzzy.Match(tableNameFilter, nodeText) && parent != nil {
+				parentText := strings.ToLower(parent.GetText())
+				if fuzzy.Match(databaseNameFilter, parentText) {
+					parent.SetExpanded(true)
+					tree.state.searchFoundNodes = append(tree.state.searchFoundNodes, node)
+					tree.SetCurrentNode(node)
+					tree.state.currentFocusFoundNode = node
+				}
+			}
 		}
 
 		return true


### PR DESCRIPTION
This PR modifies the search function to allow filtering of tree nodes based on both database name and table name.

The search text is split into two parts, with the first part being treated as the database name filter and the second part as the table name filter.

This allows users to more easily find specific nodes within the tree.

With one word
![image](https://github.com/user-attachments/assets/2ab71753-a82b-4d8a-b00d-1b125fe7ecff)

With two words
![image](https://github.com/user-attachments/assets/fff4157d-c0fe-4ee2-93c0-27ae1bbb8b89)

Fix #121 
