### PR TITLE
change keybind from [] to ctrl+[] for navigation between tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,8 +343,8 @@ Commands = [
 | K        | Sort ASC                             |
 | J        | Sort DESC                            |
 | H        | Focus tree panel                     |
-| [        | Focus previous tab                   |
-| ]        | Focus next tab                       |
+| CTRL+[   | Focus previous tab                   |
+| CTRL+]   | Focus next tab                       |
 | X        | Close current tab                    |
 | R        | Refresh the current table            |
 

--- a/app/keymap.go
+++ b/app/keymap.go
@@ -105,8 +105,8 @@ var Keymaps = KeymapSystem{
 			Bind{Key: Key{Char: 'K'}, Cmd: cmd.SortAsc, Description: "Sort ascending"},
 			Bind{Key: Key{Char: 'C'}, Cmd: cmd.SetValue, Description: "Toggle value menu to put values like NULL, EMPTY or DEFAULT"},
 			// Tabs
-			Bind{Key: Key{Char: '['}, Cmd: cmd.TabPrev, Description: "Switch to previous tab"},
-			Bind{Key: Key{Char: ']'}, Cmd: cmd.TabNext, Description: "Switch to next tab"},
+			Bind{Key: Key{Code: tcell.KeyCtrlLeftSq}, Cmd: cmd.TabPrev, Description: "Switch to previous tab"},
+			Bind{Key: Key{Code: tcell.KeyCtrlRightSq}, Cmd: cmd.TabNext, Description: "Switch to next tab"},
 			Bind{Key: Key{Char: '{'}, Cmd: cmd.TabFirst, Description: "Switch to first tab"},
 			Bind{Key: Key{Char: '}'}, Cmd: cmd.TabLast, Description: "Switch to last tab"},
 			Bind{Key: Key{Char: 'X'}, Cmd: cmd.TabClose, Description: "Close tab"},


### PR DESCRIPTION
This is a breaking change
The issue is that query editor doesn't allow to enter [] characters because they are bound to tab navigation
I'm not sure if this is the best way to fix it but it works and seems sensible.