### PR TITLE
feat: Implement responsive grid layout for connection pages

### DIFF
--- a/components/connection_page.go
+++ b/components/connection_page.go
@@ -7,25 +7,41 @@ import (
 )
 
 func NewConnectionPages() *models.ConnectionPages {
-	wrapper := tview.NewFlex()
-	container := tview.NewFlex().SetDirection(tview.FlexColumnCSS)
-
+	// Create pages component
 	pages := tview.NewPages()
-
-	wrapper.SetDirection(tview.FlexRowCSS)
-
 	pages.SetBorder(true)
 
-	container.AddItem(nil, 0, 1, false)
-	container.AddItem(pages, 0, 1, true)
-	container.AddItem(nil, 0, 1, false)
+	// Create a grid for both small and large screens
+	smallScreenGrid := tview.NewGrid().
+		SetRows(1, 0, 1).    // Top, center, and bottom rows (center is flexible)
+		SetColumns(1, 0, 1). // Left, center, and right columns (center is flexible)
+		SetMinSize(1, 1)     // Minimum cell size
 
-	wrapper.AddItem(nil, 0, 1, false)
-	wrapper.AddItem(container, 0, 1, true)
-	wrapper.AddItem(nil, 0, 1, false)
+	// Add pages to the small screen grid (with small margins)
+	smallScreenGrid.AddItem(pages, 0, 0, 3, 3, 0, 0, true)
+
+	// Create a grid specifically for large screens with a more compact center box
+	largeScreenGrid := tview.NewGrid().
+		SetRows(0, 20, 0).    // Top margin, fixed center height, bottom margin
+		SetColumns(0, 70, 0). // Left margin, fixed center width, right margin
+		SetMinSize(1, 1)      // Minimum cell size
+
+	// Add pages to the center of large screen grid
+	largeScreenGrid.AddItem(pages, 1, 1, 1, 1, 0, 0, true)
+
+	// Create a responsive grid that switches between small and large layouts
+	mainGrid := tview.NewGrid().
+		SetRows(0).
+		SetColumns(0)
+
+	// Add the small screen layout as default
+	mainGrid.AddItem(smallScreenGrid, 0, 0, 1, 1, 0, 0, true)
+
+	// Add the large screen layout for screens with width > 100
+	mainGrid.AddItem(largeScreenGrid, 0, 0, 1, 1, 0, 100, true)
 
 	cp := &models.ConnectionPages{
-		Flex:  wrapper,
+		Grid:  mainGrid,
 		Pages: pages,
 	}
 

--- a/components/pages.go
+++ b/components/pages.go
@@ -11,6 +11,6 @@ var mainPages *tview.Pages
 func MainPages() *tview.Pages {
 	mainPages = tview.NewPages()
 	mainPages.SetBackgroundColor(app.Styles.PrimitiveBackgroundColor)
-	mainPages.AddPage(pageNameConnections, NewConnectionPages().Flex, true, true)
+	mainPages.AddPage(pageNameConnections, NewConnectionPages().Grid, true, true)
 	return mainPages
 }

--- a/models/models.go
+++ b/models/models.go
@@ -39,7 +39,7 @@ type StateChange struct {
 }
 
 type ConnectionPages struct {
-	*tview.Flex
+	*tview.Grid
 	*tview.Pages
 }
 


### PR DESCRIPTION
Makes the connection selector page full screen on small window sizes and on larger sizes, a centered box as always, just a bit bigger.

Fixes #148 