### PR TITLE
feat: Lazysql can be embedded in applications that already have a sqlite driver registered

### DIFF
--- a/drivers/sqlite.go
+++ b/drivers/sqlite.go
@@ -6,9 +6,6 @@ import (
 	"fmt"
 	"strings"
 
-	// import sqlite driver
-	_ "modernc.org/sqlite"
-
 	"github.com/jorgerojas26/lazysql/models"
 )
 

--- a/drivers/sqlite_driver.go
+++ b/drivers/sqlite_driver.go
@@ -1,0 +1,8 @@
+//go:build !disable_sqlite_import
+
+package drivers
+
+// import sqlite driver
+import (
+	_ "modernc.org/sqlite"
+)


### PR DESCRIPTION
When trying to use lazysql inside an existing project, I run into 
```
panic: sql: Register called twice for driver sqlite
```

This is because modernc runs the init() function when imported.
The problem is that the other project needs the import to use gorm. Lazysql only imports it to use the sqlite driver.
Adding this build tag would fix this issue.

Open to suggestions.