### PR TITLE
feat: declare config file from the command line

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -98,8 +98,9 @@ func (a *Application) Register() func() {
 }
 
 // Run starts and blocks until the application is stopped.
-func (a *Application) Run(root *tview.Pages) error {
+func (a *Application) Run(root *tview.Pages, configFile string) error {
 	a.SetRoot(root, true)
+	a.config.ConfigFile = configFile
 	return a.Application.Run()
 }
 

--- a/app/config.go
+++ b/app/config.go
@@ -13,6 +13,7 @@ import (
 )
 
 type Config struct {
+	ConfigFile  string
 	AppConfig   *models.AppConfig   `toml:"application"`
 	Connections []models.Connection `toml:"database"`
 }
@@ -26,7 +27,7 @@ func defaultConfig() *Config {
 	}
 }
 
-func defaultConfigFile() (string, error) {
+func DefaultConfigFile() (string, error) {
 	configDir := os.Getenv("XDG_CONFIG_HOME")
 	if configDir == "" {
 		dir, err := os.UserConfigDir()
@@ -38,12 +39,7 @@ func defaultConfigFile() (string, error) {
 	return filepath.Join(configDir, "lazysql", "config.toml"), nil
 }
 
-func LoadConfig() error {
-	configFile, err := defaultConfigFile()
-	if err != nil {
-		return err
-	}
-
+func LoadConfig(configFile string) error {
 	file, err := os.ReadFile(configFile)
 	if err != nil && !os.IsNotExist(err) {
 		return err
@@ -64,16 +60,11 @@ func LoadConfig() error {
 func (c *Config) SaveConnections(connections []models.Connection) error {
 	c.Connections = connections
 
-	configFile, err := defaultConfigFile()
-	if err != nil {
+	if err := os.MkdirAll(filepath.Dir(c.ConfigFile), 0o755); err != nil {
 		return err
 	}
 
-	if err = os.MkdirAll(filepath.Dir(configFile), 0o755); err != nil {
-		return err
-	}
-
-	file, err := os.Create(configFile)
+	file, err := os.Create(c.ConfigFile)
 	if err != nil {
 		return err
 	}

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 var version = "dev"
 
 func main() {
+	defaultConfigPath, err := app.DefaultConfigFile()
 	flag.Usage = func() {
 		f := flag.CommandLine.Output()
 		fmt.Fprintln(f, "lazysql")
@@ -28,6 +29,7 @@ func main() {
 		fmt.Fprintln(f, "Options:")
 		flag.PrintDefaults()
 	}
+	configFile := flag.String("config", defaultConfigPath, "config file to use")
 	printVersion := flag.Bool("version", false, "Show version")
 	logLevel := flag.String("loglevel", "info", "Log level")
 	logFile := flag.String("logfile", "", "Log file")
@@ -57,7 +59,7 @@ func main() {
 	}
 
 	// First load the config.
-	if err = app.LoadConfig(); err != nil {
+	if err = app.LoadConfig(*configFile); err != nil {
 		log.Fatalf("Error loading config: %v", err)
 	}
 
@@ -80,7 +82,7 @@ func main() {
 		log.Fatal("Only a single connection is allowed")
 	}
 
-	if err = app.App.Run(mainPages); err != nil {
+	if err = app.App.Run(mainPages, *configFile); err != nil {
 		log.Fatalf("Error running app: %v", err)
 	}
 }


### PR DESCRIPTION
Adds a command-line flag to pick up configuration for user-defined file, enabling per-repo configurations. Defaults to `~/.config/lazysql/config.toml` if not specified.

Related #155 