### PR TITLE
Allow MSSQL connections from the CLI

### DIFF
--- a/components/arg_connection.go
+++ b/components/arg_connection.go
@@ -35,6 +35,8 @@ func InitFromArg(connectionString string) error {
 		newDBDriver = &drivers.Postgres{}
 	case drivers.DriverSqlite:
 		newDBDriver = &drivers.SQLite{}
+	case drivers.DriverMSSQL:
+		newDBDriver = &drivers.MSSQL{}
 	}
 
 	err = newDBDriver.Connect(connection.URL)

--- a/components/arg_connection.go
+++ b/components/arg_connection.go
@@ -37,6 +37,8 @@ func InitFromArg(connectionString string) error {
 		newDBDriver = &drivers.SQLite{}
 	case drivers.DriverMSSQL:
 		newDBDriver = &drivers.MSSQL{}
+	default:
+		return fmt.Errorf("could not handle database driver %s", connection.Provider)
 	}
 
 	err = newDBDriver.Connect(connection.URL)


### PR DESCRIPTION
```
lazysql sqlserver://user:pass@localhost
```
currently produces a nil dereference with the following output
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xc0000005 code=0x0 addr=0x18 pc=0x10a8a18]

goroutine 1 [running]:
github.com/jorgerojas26/lazysql/components.InitFromArg({0xc00000a160, 0xc})
        C:/Users/CalebHunt/go/pkg/mod/github.com/jorgerojas26/lazysql@v0.3.7/components/arg_connection.go:40 +0x218
main.main()
        C:/Users/CalebHunt/go/pkg/mod/github.com/jorgerojas26/lazysql@v0.3.7/main.go:75 +0x2fa
```

To fix it, we just need to add a case to `arg_connection`'s `InitFromArg` to handle the `drivers.DriverMSSQL` case.  
To make it easier for future users, I also added a `default` to the `switch` to produce a human-readable error.

First time contributor, so please let me know if I'm breaking the flow here!