### PR TITLE
Implement user-define variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,9 +152,10 @@ The configuration file is a TOML file and can be used to define multiple connect
 Name = 'Production database'
 Provider = 'postgres'
 DBName = 'foo'
-URL = 'postgres://postgres:urlencodedpassword@localhost:${port}/foo'
+URL = 'postgres://${user}:urlencodedpassword@localhost:${port}/foo'
 Commands = [
-  { Command = 'ssh -tt remote-bastion -L ${port}:localhost:5432', WaitForPort = '${port}' }
+  { Command = 'ssh -tt remote-bastion -L ${port}:localhost:5432', WaitForPort = '${port}' },
+  { Command = 'whoami', SaveOutputTo = 'user' },
 ]
 [[database]]
 Name = 'Development database'
@@ -288,14 +289,16 @@ to the database. You can define these commands in the configuration file like th
 Name = 'server'
 Provider = 'postgres'
 DBName = 'foo'
-URL = 'postgres://postgres:password@localhost:${port}/foo'
+URL = 'postgres://${user}:password@localhost:${port}/foo'
 Commands = [
-  { Command = 'ssh -tt remote-bastion -L ${port}:localhost:5432', WaitForPort = '${port}' }
+  { Command = 'ssh -tt remote-bastion -L ${port}:localhost:5432', WaitForPort = '${port}' },
+  { Command = 'whoami', SaveOutputTo = 'user' },
 ]
 ```
 
 The `Command` field is required and can contain any command that you would normally run in your terminal.
 The `WaitForPort` field is optional and can be used to wait for a specific port to be open before continuing.
+The `SaveOutputTo` field is optional and can be used to make user-defined variables. The output (`stdout`) from the command will be saved into the variable, and the variable can be used in the URL or future commands via the `${VARIABLE}` syntax.
 
 When you define the `${port}` variable in the URL field, lazysql will automatically replace it with a random
 free port number. This port number will then be used in the connection URL and is available in the `Commands`

--- a/models/models.go
+++ b/models/models.go
@@ -29,8 +29,9 @@ type Connection struct {
 }
 
 type Command struct {
-	Command     string
-	WaitForPort string
+	Command      string
+	WaitForPort  string
+	SaveOutputTo string
 }
 
 type StateChange struct {


### PR DESCRIPTION
Implements: #156

Any thoughts on the `SaveOutputTo` field name?

I'm also not in love with the `waitToCaptureVariable` solution. I think it would make more sense for the `helpers.RunCommand` to return a `<- chan string` with the output, and then we could `onDone := App.Register(); go func() { _ = <- c; onDone() }()`. In other words, `RunCommand` doesn't take in the `onDone` callback; it just gives out a channel which we can use to synchronize. I didn't feel like it was important enough to figure it out here though.  
Similarly, I'm unhappy with the `io.MultiWriter` usage. It feels a bit hacky to me.

Also, in case you're curious, here's my original use case for this feature: I have two MSSQL instances on my machine. If you have just one, it's typically on `localhost:1433`, but with two, their ports are actually dynamic. At time of writing, my connection string is `sqlserver://user:pass@localhost:47904`, but that port will randomize on restart! So I wrote a powershell script to get it. Now I set up my config.toml like
```toml
[[database]]
# ...
URL = 'sqlserver://user:pass@localhost:${dynamicPort}'
Commands = [
  { Command = 'powershell.exe get-port.ps1', SaveOutputTo = 'dynamicPort' }
]
```