### PR TITLE
Preserve selected cell position after table sort

### DIFF
--- a/components/results_table.go
+++ b/components/results_table.go
@@ -893,7 +893,9 @@ func (table *ResultsTable) SetSortedBy(column string, direction string) {
 		if err != nil {
 			table.SetError(err.Error(), nil)
 		} else {
+			previousRow, previousColumn := table.GetSelection()
 			table.SetRecords(records)
+			table.Select(previousRow, previousColumn)
 			App.ForceDraw()
 		}
 


### PR DESCRIPTION
When you do a ASC or DESC sort with shift + j or k, the selected cell is reset and go back to start.

This MR allows the same cell to stay selected after the sort.