### PR TITLE
Add the possibility to search in the help modal for key binding

### DIFF
--- a/components/help_modal.go
+++ b/components/help_modal.go
@@ -127,8 +127,8 @@ func (modal *HelpModal) fillTable(filter string) {
 		var groupBinds []keymap.Bind
 		for _, bind := range group.Binds {
 			if filter != "" &&
-				!strings.Contains(strings.ToLower(bind.Description), strings.ToLower(filter)) &&
-				!strings.Contains(strings.ToLower(bind.Key.String()), strings.ToLower(filter)) {
+				!strings.Contains(strings.ReplaceAll(strings.ToLower(bind.Description), " ", ""), strings.ReplaceAll(strings.ToLower(filter), " ", "")) &&
+				!strings.Contains(strings.ReplaceAll(strings.ToLower(bind.Key.String()), " ", ""), strings.ReplaceAll(strings.ToLower(filter), " ", "")) {
 				continue
 			}
 			groupBinds = append(groupBinds, bind)


### PR DESCRIPTION
To make it faster and more user friendly to find some key binding this MR add the search on the help page when pressing the "/" touch.

for example to search for the "Go to top" key, you can search "goto"