### PR TITLE
FIX : remove the sorting icon from the column name when editing cell

### DIFF
--- a/components/results_table.go
+++ b/components/results_table.go
@@ -1020,6 +1020,10 @@ func (table *ResultsTable) StartEditingCell(row int, col int, callback func(newV
 		newValue := inputField.GetText()
 		columnName := table.GetCell(0, col).Text
 
+		// Remove the sorting icon from the column name
+		columnName = strings.ReplaceAll(columnName, " ▼", "")
+		columnName = strings.ReplaceAll(columnName, " ▲", "")
+
 		if key != tcell.KeyEscape {
 			cell.SetText(newValue)
 


### PR DESCRIPTION
fix this issue : [https://github.com/jorgerojas26/lazysql/issues/223](https://github.com/jorgerojas26/lazysql/issues/223)