### PR TITLE
Tree filter rank results

### DIFF
--- a/components/tree.go
+++ b/components/tree.go
@@ -194,7 +194,9 @@ func NewTree(dbName string, dbdriver drivers.Driver) *Tree {
 			if filterText == "" {
 				tree.ClearSearch()
 			} else {
-				tree.FoundNodeCountInput.SetText(fmt.Sprintf("[%d/%d]", len(tree.state.searchFoundNodes), len(tree.state.searchFoundNodes)))
+				if len(tree.state.searchFoundNodes) > 0 {
+					tree.FoundNodeCountInput.SetText(fmt.Sprintf("[1/%d]", len(tree.state.searchFoundNodes)))
+				}
 				tree.SetBorderPadding(1, 0, 0, 0)
 			}
 


### PR DESCRIPTION
## Summary

Employ a "rank" system so stronger matches are found first.

## Why

I love lazysql - been using it exclusively for work for the past week.
In large schemas (hundreds of DBs, thousands of tables), fuzzy search can often put loosely-related names ahead of obvious targets. Example: querying `sites` in my work db returns ~34 hits with `sites` buried among `settings_categories`, `jobsites`, etc. This change prioritizes stronger lexical matches before falling back to fuzzy, so obvious hits appear first.

## What
1. exact match has the best ranking
2. prefix match is 2nd best, scored based on length difference
3. substr match is 3rd best, scored based on substr position and length difference
4. fallback to fuzzy - but using RankMatch instead of Match, so fuzzy results are ranked by proximity to query

## Original Result
For search term `sites`:
1. `settings_categories`
2. `crm_jobsites`
3. `els_point_records`
4. `els_point_types`
5. ...
6. `sites` (the exact match) is result 29/34

## Result After the Change

When I search for `sites`, the results are as follows:

1. `sites`
7. `crm_jobsites`
8. `els_point_types`
9. `els_point_records`
10. etc...

## Notes

I did also fix another thing - submitting a filter query shows the first result as [34/34] instead of [1/34]. Now it shows 1/N and counts properly as you iterate through results.

## Testing

Something like this:

1. [ ] Create a database with a table called `gallery`
11. [ ] create another table called `erygall`
12. [ ] try searching for `gallery` and ensure the correct match shows up first
13. [ ] try searching for `erygall` and ensure the exact match shows up first
14. [ ] try searching for `gall` - gallery should show up first
15. [ ] try searching for `lagerly` and ensure that fuzzy match still brings up the results (preserving the original functionality)

