### PR TITLE
feat: add environment variable support in config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
     </li>
     <li><a href="#usage">Usage</a></li>
     <li><a href="#commands">Commands</a></li>
+    <li><a href="#environment-variables">Environment variables</a></li>
     <li><a href="#keybindings">Keybindings</a></li>
     <li><a href="#roadmap">Roadmap</a></li>
     <li><a href="#contributing">Contributing</a></li>
@@ -326,6 +327,25 @@ Commands = [
   { Command = 'kubectl port-forward service/postgres ${port}:5432 --kubeconfig /path/to/kube.conf', WaitForPort = '${port}' }
 ]
 ```
+
+## Environment variables
+
+You can use environment variables in the configuration file using the `${env:VAR_NAME}` syntax. This is useful for keeping sensitive information like passwords out of the configuration file.
+
+```toml
+[[database]]
+Name = 'Production'
+Provider = 'postgres'
+URL = 'postgres://${env:DB_USER}:${env:DB_PASSWORD}@localhost:5432/mydb'
+```
+
+```bash
+export DB_USER=admin
+export DB_PASSWORD=secret
+lazysql
+```
+
+Note: Undefined environment variables will be replaced with an empty string.
 
 <!-- KEYBINDINGS -->
 

--- a/app/config.go
+++ b/app/config.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/pelletier/go-toml/v2"
 
@@ -58,7 +59,10 @@ func LoadConfig(configFile string) error {
 		return err
 	}
 
-	err = toml.Unmarshal(file, App.config)
+	// Expand environment variables in the config file before parsing
+	expanded := expandEnvVars(string(file))
+
+	err = toml.Unmarshal([]byte(expanded), App.config)
 	if err != nil {
 		return err
 	}
@@ -68,6 +72,19 @@ func LoadConfig(configFile string) error {
 	}
 
 	return nil
+}
+
+// expandEnvVars expands environment variables in the format ${env:VAR_NAME}.
+// Variables without the "env:" prefix (e.g., ${port}) are left unchanged
+// to maintain compatibility with dynamic variables used at connection time.
+func expandEnvVars(s string) string {
+	return os.Expand(s, func(key string) string {
+		if envKey, found := strings.CutPrefix(key, "env:"); found {
+			return os.Getenv(envKey)
+		}
+		// Keep non-env variables unchanged (e.g., ${port})
+		return "${" + key + "}"
+	})
 }
 
 func (c *Config) SaveConnections(connections []models.Connection) error {

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -1,0 +1,52 @@
+package app
+
+import (
+	"testing"
+)
+
+func TestExpandEnvVars(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		envVars  map[string]string
+		expected string
+	}{
+		{
+			name:     "expand env var",
+			input:    "postgres://${env:DB_USER}:${env:DB_PASSWORD}@localhost/db",
+			envVars:  map[string]string{"DB_USER": "admin", "DB_PASSWORD": "secret"},
+			expected: "postgres://admin:secret@localhost/db",
+		},
+		{
+			name:     "preserve dynamic variables",
+			input:    "postgres://user:pass@localhost:${port}/db",
+			envVars:  map[string]string{},
+			expected: "postgres://user:pass@localhost:${port}/db",
+		},
+		{
+			name:     "mix env vars and dynamic variables",
+			input:    "postgres://${env:DB_USER}:${env:DB_PASSWORD}@localhost:${port}/db",
+			envVars:  map[string]string{"DB_USER": "admin", "DB_PASSWORD": "secret"},
+			expected: "postgres://admin:secret@localhost:${port}/db",
+		},
+		{
+			name:     "undefined env var becomes empty",
+			input:    "postgres://${env:UNDEFINED_VAR}@localhost/db",
+			envVars:  map[string]string{},
+			expected: "postgres://@localhost/db",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for key, value := range tt.envVars {
+				t.Setenv(key, value)
+			}
+
+			result := expandEnvVars(tt.input)
+			if result != tt.expected {
+				t.Errorf("expandEnvVars(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Thanks for building lazysql!

## Summary

This is a feature proposal to support environment variables in the config file using the `${env:VAR_NAME}` syntax.

## Motivation

Managing credentials like passwords via environment variables is a common practice, and it's something I do regularly. I wanted to avoid storing them in plaintext in config files.

## Design decisions

I chose the `${env:VAR_NAME}` syntax to maintain compatibility with existing dynamic variables like `${port}`. I'd love to hear your thoughts on this approach.