### PR TITLE
Add optional timeout parameter to commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,11 +151,12 @@ The configuration file is a TOML file and can be used to define multiple connect
 Name = 'Production database'
 Provider = 'postgres'
 DBName = 'foo'
-URL = 'postgres://${user}:urlencodedpassword@localhost:${port}/foo'
+URL = 'postgres://${user}:${password}@localhost:${port}/foo'
 ReadOnly = true
 Commands = [
   { Command = 'ssh -tt remote-bastion -L ${port}:localhost:5432', WaitForPort = '${port}' },
   { Command = 'whoami', SaveOutputTo = 'user' },
+  { Command = 'op read -nf op://Vault/Database/password', TimeoutSeconds = 5, SaveOutputTo = 'password' },
 ]
 [[database]]
 Name = 'Development database'

--- a/helpers/command.go
+++ b/helpers/command.go
@@ -15,7 +15,7 @@ import (
 )
 
 // [doneFn] is invoked when the [command] is completed with its stdout.
-func RunCommand(ctx context.Context, command string, doneFn func(output string)) error {
+func RunCommand(ctx context.Context, command string, timeout time.Duration, doneFn func(output string)) error {
 	var cmd *exec.Cmd
 
 	parts := strings.Fields(command)
@@ -58,7 +58,7 @@ func RunCommand(ctx context.Context, command string, doneFn func(output string))
 		logger.Error("Command canceled", map[string]any{"error": ctx.Err()})
 	case <-startedCh:
 		logger.Info("Command started", map[string]any{"command": command})
-	case <-time.After(5 * time.Second):
+	case <-time.After(timeout):
 		_ = cmd.Process.Kill()
 		return errors.New("command timeout")
 	}

--- a/models/models.go
+++ b/models/models.go
@@ -34,9 +34,10 @@ type Connection struct {
 }
 
 type Command struct {
-	Command      string
-	WaitForPort  string
-	SaveOutputTo string
+	Command        string
+	WaitForPort    string
+	SaveOutputTo   string
+	TimeoutSeconds int
 }
 
 type StateChange struct {


### PR DESCRIPTION
External commands run for a given database connection may now have an
optional `TimeoutSeconds` parameter included, giving users the ability
to change the timeout duration from the default 5 seconds.

Update to the README includes a practical example for fetching a database password from a
password manager, which is likely to block while the user enters their
master password
