### PR TITLE
fix: hostname parsing of postgres url

### DIFF
--- a/drivers/postgres.go
+++ b/drivers/postgres.go
@@ -812,7 +812,7 @@ func (db *Postgres) SwitchDatabase(database string) error {
 
 	user := parsedConn.User.Username()
 	password, _ := parsedConn.User.Password()
-	host := parsedConn.Host
+	host := parsedConn.Hostname()
 	port := parsedConn.Port()
 	dbname := parsedConn.Path
 


### PR DESCRIPTION
Hello,

This pull request addresses #189.

When connecting to a Postgres database without a database name (e.g. `lazysql postgres://postgres:postgres@localhost:5432?sslmode=disable`), the TUI shows databases but you cannot open any.

Error observed:
```
{"timestamp":"2026-01-29T18:45:07+01:00","level":"ERROR","message":"dial tcp: lookup localhost:5432: no such host"}
```

Root cause: SwitchDatabase used the URL's Host field (which includes port) instead of the hostname alone.