### PR TITLE
feat: add TreeWidth config option for tree pane width

### DIFF
--- a/app/config.go
+++ b/app/config.go
@@ -24,6 +24,7 @@ func defaultConfig() *Config {
 			DefaultPageSize:              300,
 			SidebarOverlay:               false,
 			MaxQueryHistoryPerConnection: 100,
+			TreeWidth:                    30,
 		},
 	}
 }

--- a/components/home.go
+++ b/components/home.go
@@ -105,7 +105,7 @@ func NewHomePage(connection models.Connection, dbdriver drivers.Driver) *Home {
 	rightWrapper.AddItem(tabbedPane.HeaderContainer, 1, 0, false)
 	rightWrapper.AddItem(tabbedPane.Pages, 0, 1, false)
 
-	maincontent.AddItem(leftWrapper, 30, 1, false)
+	maincontent.AddItem(leftWrapper, app.App.Config().TreeWidth, 1, false)
 	maincontent.AddItem(rightWrapper, 0, 5, false)
 
 	home.AddItem(maincontent, 0, 1, false)
@@ -552,7 +552,7 @@ func (home *Home) toggleLeftWrapper() {
 		home.focusRightWrapper()
 	} else {
 		home.MainContent.Clear()
-		home.MainContent.AddItem(home.LeftWrapper, 30, 1, false)
+		home.MainContent.AddItem(home.LeftWrapper, app.App.Config().TreeWidth, 1, false)
 		home.MainContent.AddItem(home.RightWrapper, 0, 5, false)
 		home.leftWrapperVisible = true
 		home.focusLeftWrapper()

--- a/models/models.go
+++ b/models/models.go
@@ -11,6 +11,7 @@ type AppConfig struct {
 	DisableSidebar               bool
 	SidebarOverlay               bool
 	MaxQueryHistoryPerConnection int
+	TreeWidth                    int
 }
 
 type Connection struct {


### PR DESCRIPTION
Thank you for this great tool!

## Summary

- Add `TreeWidth` option to `[application]` config section
- Allows users to customize the width of the left tree pane (database/table navigation)
- Default value is 30 (preserves existing behavior)

## Usage

```toml
[application]
TreeWidth = 50  # wider tree pane to see full table names
```

Closes #239