### PR TITLE
feat: add Schemas config option to filter schemas in tree

### DIFF
--- a/components/home.go
+++ b/components/home.go
@@ -37,7 +37,7 @@ type Home struct {
 }
 
 func NewHomePage(connection models.Connection, dbdriver drivers.Driver) *Home {
-	tree := NewTree(connection.DBName, dbdriver)
+	tree := NewTree(connection.DBName, dbdriver, connection.Schemas)
 	leftWrapper := tview.NewFlex()
 	rightWrapper := tview.NewFlex()
 

--- a/models/models.go
+++ b/models/models.go
@@ -30,6 +30,10 @@ type Connection struct {
 
 	ReadOnly bool
 
+	// Schemas filters the schemas shown in the tree (PostgreSQL/MSSQL only).
+	// If empty, all schemas are shown.
+	Schemas []string
+
 	Commands []*Command
 }
 


### PR DESCRIPTION
Add a `Schemas` configuration option to filter which schemas are displayed in the tree view for PostgreSQL and MSSQL connections.

This is useful when working with databases that have many schemas (e.g., `information_schema`, `pg_catalog`, etc.) but you only want to see specific ones.

## Example Configuration

```yaml
[[database]]
...
Schemas = ['public']
```
