### PR TITLE
feat: add dynamic resize of tree width

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 <a name="readme-top"></a>
 
 [![Contributors][contributors-shield]][contributors-url]
-[![Forks][forks-shield]][forks-url]
-[![Stargazers][stars-shield]][stars-url]
+[![Forks][forks-shield]][forks-url] [![Stargazers][stars-shield]][stars-url]
 [![Issues][issues-shield]][issues-url]
 [![MIT License][license-shield]][license-url]
 [![LinkedIn][linkedin-shield]][linkedin-url]
@@ -13,9 +12,9 @@
   <!--   <img src="images/logo.png" alt="Logo" width="80" height="80"> -->
   <!-- </a> -->
 
-  <h3 align="center">LAZYSQL</h3>
+<h3 align="center">LAZYSQL</h3>
 
-  <p align="center">
+<p align="center">
         A cross-platform TUI database management tool written in Go.
   </p>
 </div>
@@ -56,22 +55,31 @@
 ![Product Name Screen Shot][product-screenshot1]
 ![Product Name Screen Shot][product-screenshot2]
 
-This project is heavily inspired by [Lazygit](https://github.com/jesseduffield/lazygit), which I think is the best TUI client for Git.
+This project is heavily inspired by
+[Lazygit](https://github.com/jesseduffield/lazygit), which I think is the best
+TUI client for Git.
 
-I wanted to have a tool like that, but for SQL. I didn't find one that fits my needs, so I created one myself.
+I wanted to have a tool like that, but for SQL. I didn't find one that fits my
+needs, so I created one myself.
 
-I live in the terminal, so if you are like me, this tool can become handy for you too.
+I live in the terminal, so if you are like me, this tool can become handy for
+you too.
 
-This is my first Open Source project, also, this is my first Go project. I am not a brilliant programmer. I am just a typical JavaScript developer that wanted to learn a new language, I also wanted a TUI SQL Client, so blanca y en botella, leche! (white and bottled).
+This is my first Open Source project, also, this is my first Go project. I am
+not a brilliant programmer. I am just a typical JavaScript developer that wanted
+to learn a new language, I also wanted a TUI SQL Client, so blanca y en botella,
+leche! (white and bottled).
 
-This project is in ALPHA stage, please feel free to complain about my spaghetti code.
+This project is in ALPHA stage, please feel free to complain about my spaghetti
+code.
 
-I use Lazysql daily in my full-time job as a full-stack javascript developer in its current (buggy xD) state. So, the plan is to improve and fix my little boy as a side-project in my free time.
+I use Lazysql daily in my full-time job as a full-stack javascript developer in
+its current (buggy xD) state. So, the plan is to improve and fix my little boy
+as a side-project in my free time.
 
 ### Built With
 
-![Golang][golang-shield]
-![Golang][tview-shield]
+![Golang][golang-shield] ![Golang][tview-shield]
 
 ## Features
 
@@ -101,7 +109,8 @@ go install github.com/jorgerojas26/lazysql@latest
 
 #### Binary Releases
 
-For Windows, macOS or Linux, you can download a binary release [here](https://github.com/jorgerojas26/lazysql/releases)
+For Windows, macOS or Linux, you can download a binary release
+[here](https://github.com/jorgerojas26/lazysql/releases)
 
 #### Third party (maintained by the community)
 
@@ -109,14 +118,12 @@ Arch Linux users can install it from the AUR with:
 
 ```bash
 paru -S lazysql
-
 ```
 
 or
 
 ```bash
 yay -S lazysql
-
 ```
 
 or install it manual with:
@@ -133,7 +140,8 @@ makepkg -si
 
 ## Configuration
 
-If the `XDG_CONFIG_HOME` environment variable is set, the configuration file will be located at:
+If the `XDG_CONFIG_HOME` environment variable is set, the configuration file
+will be located at:
 
 - `${XDG_CONFIG_HOME}/lazysql/config.toml`
 
@@ -143,7 +151,8 @@ If not, the configuration file will be located at:
 - macOS: `~/Library/Application Support/lazysql/config.toml`
 - Linux: `~/.config/lazysql/config.toml`
 
-The configuration file is a TOML file and can be used to define multiple connections.
+The configuration file is a TOML file and can be used to define multiple
+connections.
 
 ### Example configuration
 
@@ -169,20 +178,25 @@ DisableSidebar = false
 SidebarOverlay = false
 ```
 
-The `ReadOnly` field (optional, defaults to `false`) can be set to `true` to enable read-only mode for a connection. When enabled, all mutation queries (INSERT, UPDATE, DELETE, DROP, etc.) will be blocked.
+The `ReadOnly` field (optional, defaults to `false`) can be set to `true` to
+enable read-only mode for a connection. When enabled, all mutation queries
+(INSERT, UPDATE, DELETE, DROP, etc.) will be blocked.
 
-The `[application]` section is used to define some app settings. Not all settings are available yet, this is a work in progress.
+The `[application]` section is used to define some app settings. Not all
+settings are available yet, this is a work in progress.
 
 ## Usage
 
 > For a list of keyboard shortcuts press `?`
 
 Open the TUI with:
+
 ```console
 $ lazysql
 ```
 
 To launch lazysql with the ability to pick from the saved connections.
+
 ```console
 $ lazysql [connection_url]
 ```
@@ -199,21 +213,24 @@ To launch lazysql in read-only mode.
 
 1. Start `lazysql`
 2. Create a new connection (press `n`)
-3. Provide a name for the connection as well as the URL to connect to (see <a href="#example-connection-urls">example connection URL</a>)
+3. Provide a name for the connection as well as the URL to connect to (see
+   <a href="#example-connection-urls">example connection URL</a>)
 4. Connect to the DB (press `<Enter>`)
 
 If you already have a connection set up:
+
 1. Start `lazysql`
 2. Select the right connection (press `j` and `h` for navigation)
 3. Connect to the DB (press `c` or `<Enter>`)
 
 ### Create a table
 
-There is currently no way to create a table from the TUI.
-However you can run the query to create the table as a SQL-Query,
-inside the <a href="#execute-sql-queries">SQL Editor</a>.
+There is currently no way to create a table from the TUI. However you can run
+the query to create the table as a SQL-Query, inside the
+<a href="#execute-sql-queries">SQL Editor</a>.
 
-You can update the tree by pressing `R`, so you can see your newly created table.
+You can update the tree by pressing `R`, so you can see your newly created
+table.
 
 ### Execute SQL queries
 
@@ -223,21 +240,21 @@ You can update the tree by pressing `R`, so you can see your newly created table
 
 > To switch back to the table-tree press `H`
 >
-> After executing a `SELECT`-query a table will be displayed under the SQL-Editor
-> with the query-result. \
+> After executing a `SELECT`-query a table will be displayed under the
+> SQL-Editor with the query-result.\
 > To switch focus back to SQL-Editor press `/`
 
 ### Open/view a table
 
 1. Expand the table-tree by pressing `e` or `<Enter>`
 2. Select the table you want to view
-    - next node `j`
-    - previous node `k`
-    - last node `G`
-    - first node `g`
+   - next node `j`
+   - previous node `k`
+   - last node `G`
+   - first node `g`
 3. Press `<Enter>` to open the table
 
-> To switch back to the table-tree press `H` \
+> To switch back to the table-tree press `H`\
 > To switch back to the table press `L`
 
 ### Filter rows
@@ -277,7 +294,9 @@ You can update the tree by pressing `R`, so you can see your newly created table
    - Export Current Page: Export only the currently displayed rows
    - Export All Records: Fetch and export all records from the table
 
-> Batch size (default: 10000): When exporting all records, data is fetched in batches to avoid timeout or memory issues with large tables. Increase for faster exports, decrease if you encounter any errors.
+> Batch size (default: 10000): When exporting all records, data is fetched in
+> batches to avoid timeout or memory issues with large tables. Increase for
+> faster exports, decrease if you encounter any errors.
 >
 > The default file path is `~/Downloads/{database}_{table}_{timestamp}.csv`.
 
@@ -304,17 +323,19 @@ Support for multiple RDBMS is a work in progress.
 
 ## Commands
 
-In some cases, mostly when connecting to remote databases, it might be necessary to run a custom command
-before being able to connect to the database. For example when you can only access the database through
-a remote bastion, you would probably first need to open an SSH tunnel by running the following command
+In some cases, mostly when connecting to remote databases, it might be necessary
+to run a custom command before being able to connect to the database. For
+example when you can only access the database through a remote bastion, you
+would probably first need to open an SSH tunnel by running the following command
 in a separate terminal:
 
 ```bash
 ssh remote-bastion -L 5432:localhost:5432
 ```
 
-In order to make it easier to run these commands, lazysql supports running custom commands before connecting
-to the database. You can define these commands in the configuration file like this:
+In order to make it easier to run these commands, lazysql supports running
+custom commands before connecting to the database. You can define these commands
+in the configuration file like this:
 
 ```toml
 [[database]]
@@ -328,16 +349,20 @@ Commands = [
 ]
 ```
 
-The `Command` field is required and can contain any command that you would normally run in your terminal.
-The `WaitForPort` field is optional and can be used to wait for a specific port to be open before continuing.
-The `SaveOutputTo` field is optional and can be used to make user-defined variables. The output (`stdout`) from the command will be saved into the variable, and the variable can be used in the URL or future commands via the `${VARIABLE}` syntax.
+The `Command` field is required and can contain any command that you would
+normally run in your terminal. The `WaitForPort` field is optional and can be
+used to wait for a specific port to be open before continuing. The
+`SaveOutputTo` field is optional and can be used to make user-defined variables.
+The output (`stdout`) from the command will be saved into the variable, and the
+variable can be used in the URL or future commands via the `${VARIABLE}` syntax.
 
-When you define the `${port}` variable in the URL field, lazysql will automatically replace it with a random
-free port number. This port number will then be used in the connection URL and is available in the `Commands`
-field so that you can use it to configure the command.
+When you define the `${port}` variable in the URL field, lazysql will
+automatically replace it with a random free port number. This port number will
+then be used in the connection URL and is available in the `Commands` field so
+that you can use it to configure the command.
 
-You can even chain commands to, for example, connect to a remote server and then to a postgres container
-running in a remote k8s cluster:
+You can even chain commands to, for example, connect to a remote server and then
+to a postgres container running in a remote k8s cluster:
 
 ```toml
 [[database]]
@@ -353,7 +378,9 @@ Commands = [
 
 ## Environment variables
 
-You can use environment variables in the configuration file using the `${env:VAR_NAME}` syntax. This is useful for keeping sensitive information like passwords out of the configuration file.
+You can use environment variables in the configuration file using the
+`${env:VAR_NAME}` syntax. This is useful for keeping sensitive information like
+passwords out of the configuration file.
 
 ```toml
 [[database]]
@@ -376,7 +403,8 @@ Note: Undefined environment variables will be replaced with an empty string.
 
 ### Custom Keybindings
 
-You can customize keybindings by adding a `[keymap.<Group>]` section to your `config.toml` file. Each entry maps a command name to a key.
+You can customize keybindings by adding a `[keymap.<Group>]` section to your
+`config.toml` file. Each entry maps a command name to a key.
 
 ```toml
 [keymap.Home]
@@ -388,112 +416,116 @@ GotoTop = "t"
 Search = "Ctrl-F"
 ```
 
-For single character keys, use the character directly (e.g., `"q"`, `"G"`, `"1"`, `"/"`). For special keys, use the [tcell key name](https://github.com/gdamore/tcell/blob/v2.7.4/key.go#L83) (e.g., `"Enter"`, `"Esc"`, `"Ctrl-S"`). Only key names defined in tcell are supported.
+For single character keys, use the character directly (e.g., `"q"`, `"G"`,
+`"1"`, `"/"`). For special keys, use the
+[tcell key name](https://github.com/gdamore/tcell/blob/v2.7.4/key.go#L83) (e.g.,
+`"Enter"`, `"Esc"`, `"Ctrl-S"`). Only key names defined in tcell are supported.
 
-Group names are case-insensitive (`Home`, `home`, and `HOME` all work).
-
-Available groups: `Home`, `Connection`, `Tree`, `TreeFilter`, `Table`, `Editor`, `Sidebar`, `QueryPreview`, `QueryHistory`, `JSONViewer`.
+Available groups: `Home`, `Connection`, `Tree`, `TreeFilter`, `Table`, `Editor`,
+`Sidebar`, `QueryPreview`, `QueryHistory`, `JSONViewer`.
 
 ### Default Keybindings
 
 #### Home
 
-| Default Key | Command | Description |
-| --- | --- | --- |
-| L | MoveRight | Focus table |
-| H | MoveLeft | Focus tree |
-| Ctrl-E | SwitchToEditorView | Open SQL editor |
-| Ctrl-S | Save | Execute pending changes |
-| q | Quit | Quit |
-| Backspace | SwitchToConnectionsView | Switch to connections list |
-| ? | HelpPopup | Help |
-| Ctrl-P | SearchGlobal | Global search |
-| Ctrl-_ | ToggleQueryHistory | Toggle query history modal |
-| T | ToggleTree | Toggle file tree |
+| Default Key | Command                 | Description                |
+| ----------- | ----------------------- | -------------------------- |
+| L           | MoveRight               | Focus table                |
+| H           | MoveLeft                | Focus tree                 |
+| Ctrl-E      | SwitchToEditorView      | Open SQL editor            |
+| Ctrl-S      | Save                    | Execute pending changes    |
+| q           | Quit                    | Quit                       |
+| Backspace   | SwitchToConnectionsView | Switch to connections list |
+| ?           | HelpPopup               | Help                       |
+| Ctrl-P      | SearchGlobal            | Global search              |
+| Ctrl-_      | ToggleQueryHistory      | Toggle query history modal |
+| T           | ToggleTree              | Toggle file tree           |
+| Ctrl-H      | TreeWidthDecrease       | Decrease tree width        |
+| Ctrl-L      | TreeWidthIncrease       | Increase tree width        |
 
 #### Connection
 
-| Default Key | Command | Description |
-| --- | --- | --- |
-| n | NewConnection | Create a new database connection |
-| c | Connect | Connect to database |
-| Enter | Connect | Connect to database |
-| e | EditConnection | Edit a database connection |
-| d | DeleteConnection | Delete a database connection |
-| q | Quit | Quit |
+| Default Key | Command          | Description                      |
+| ----------- | ---------------- | -------------------------------- |
+| n           | NewConnection    | Create a new database connection |
+| c           | Connect          | Connect to database              |
+| Enter       | Connect          | Connect to database              |
+| e           | EditConnection   | Edit a database connection       |
+| d           | DeleteConnection | Delete a database connection     |
+| q           | Quit             | Quit                             |
 
 #### Tree
 
-| Default Key | Command | Description |
-| --- | --- | --- |
-| g | GotoTop | Go to top |
-| G | GotoBottom | Go to bottom |
-| Enter | Execute | Open |
-| j | MoveDown | Go down |
-| Down | MoveDown | Go down |
-| Ctrl-U | PagePrev | Go page up |
-| Ctrl-D | PageNext | Go page down |
-| k | MoveUp | Go up |
-| Up | MoveUp | Go up |
-| / | Search | Search |
-| n | NextFoundNode | Go to next found node |
-| N | PreviousFoundNode | Go to previous found node |
-| p | PreviousFoundNode | Go to previous found node |
-| P | NextFoundNode | Go to next found node |
-| c | TreeCollapseAll | Collapse all |
-| e | ExpandAll | Expand all |
-| R | Refresh | Refresh tree |
+| Default Key | Command           | Description               |
+| ----------- | ----------------- | ------------------------- |
+| g           | GotoTop           | Go to top                 |
+| G           | GotoBottom        | Go to bottom              |
+| Enter       | Execute           | Open                      |
+| j           | MoveDown          | Go down                   |
+| Down        | MoveDown          | Go down                   |
+| Ctrl-U      | PagePrev          | Go page up                |
+| Ctrl-D      | PageNext          | Go page down              |
+| k           | MoveUp            | Go up                     |
+| Up          | MoveUp            | Go up                     |
+| /           | Search            | Search                    |
+| n           | NextFoundNode     | Go to next found node     |
+| N           | PreviousFoundNode | Go to previous found node |
+| p           | PreviousFoundNode | Go to previous found node |
+| P           | NextFoundNode     | Go to next found node     |
+| c           | TreeCollapseAll   | Collapse all              |
+| e           | ExpandAll         | Expand all                |
+| R           | Refresh           | Refresh tree              |
 
 #### Tree Filter
 
-| Default Key | Command | Description |
-| --- | --- | --- |
-| Esc | UnfocusTreeFilter | Unfocus tree filter |
-| Enter | CommitTreeFilter | Commit tree filter search |
+| Default Key | Command           | Description               |
+| ----------- | ----------------- | ------------------------- |
+| Esc         | UnfocusTreeFilter | Unfocus tree filter       |
+| Enter       | CommitTreeFilter  | Commit tree filter search |
 
 #### Table
 
-| Default Key | Command | Description |
-| --- | --- | --- |
-| / | Search | Search |
-| c | Edit | Change cell |
-| d | Delete | Delete row |
-| w | GotoNext | Go to next cell |
-| b | GotoPrev | Go to previous cell |
-| $ | GotoEnd | Go to last cell |
-| 0 | GotoStart | Go to first cell |
-| y | Copy | Copy cell value to clipboard |
-| o | AppendNewRow | Append new row |
-| O | DuplicateRow | Duplicate row |
-| J | SortDesc | Sort descending |
-| R | Refresh | Refresh the current table |
-| K | SortAsc | Sort ascending |
-| C | SetValue | Toggle value menu (NULL, EMPTY, DEFAULT) |
-| [ | TabPrev | Switch to previous tab |
-| ] | TabNext | Switch to next tab |
-| { | TabFirst | Switch to first tab |
-| } | TabLast | Switch to last tab |
-| X | TabClose | Close tab |
-| > | PageNext | Switch to next page |
-| < | PagePrev | Switch to previous page |
-| 1 | RecordsMenu | Switch to records menu |
-| 2 | ColumnsMenu | Switch to columns menu |
-| 3 | ConstraintsMenu | Switch to constraints menu |
-| 4 | ForeignKeysMenu | Switch to foreign keys menu |
-| 5 | IndexesMenu | Switch to indexes menu |
-| S | ToggleSidebar | Toggle sidebar |
-| s | FocusSidebar | Focus sidebar |
-| Z | ShowRowJSONViewer | Toggle JSON viewer for row |
-| z | ShowCellJSONViewer | Toggle JSON viewer for cell |
-| E | ExportCSV | Export to CSV |
+| Default Key | Command            | Description                              |
+| ----------- | ------------------ | ---------------------------------------- |
+| /           | Search             | Search                                   |
+| c           | Edit               | Change cell                              |
+| d           | Delete             | Delete row                               |
+| w           | GotoNext           | Go to next cell                          |
+| b           | GotoPrev           | Go to previous cell                      |
+| $           | GotoEnd            | Go to last cell                          |
+| 0           | GotoStart          | Go to first cell                         |
+| y           | Copy               | Copy cell value to clipboard             |
+| o           | AppendNewRow       | Append new row                           |
+| O           | DuplicateRow       | Duplicate row                            |
+| J           | SortDesc           | Sort descending                          |
+| R           | Refresh            | Refresh the current table                |
+| K           | SortAsc            | Sort ascending                           |
+| C           | SetValue           | Toggle value menu (NULL, EMPTY, DEFAULT) |
+| [           | TabPrev            | Switch to previous tab                   |
+| ]           | TabNext            | Switch to next tab                       |
+| {           | TabFirst           | Switch to first tab                      |
+| }           | TabLast            | Switch to last tab                       |
+| X           | TabClose           | Close tab                                |
+| >           | PageNext           | Switch to next page                      |
+| <           | PagePrev           | Switch to previous page                  |
+| 1           | RecordsMenu        | Switch to records menu                   |
+| 2           | ColumnsMenu        | Switch to columns menu                   |
+| 3           | ConstraintsMenu    | Switch to constraints menu               |
+| 4           | ForeignKeysMenu    | Switch to foreign keys menu              |
+| 5           | IndexesMenu        | Switch to indexes menu                   |
+| S           | ToggleSidebar      | Toggle sidebar                           |
+| s           | FocusSidebar       | Focus sidebar                            |
+| Z           | ShowRowJSONViewer  | Toggle JSON viewer for row               |
+| z           | ShowCellJSONViewer | Toggle JSON viewer for cell              |
+| E           | ExportCSV          | Export to CSV                            |
 
 #### Editor
 
-| Default Key | Command | Description |
-| --- | --- | --- |
-| Ctrl-R | Execute | Execute query |
-| Esc | UnfocusEditor | Unfocus editor |
-| Ctrl-Space | OpenInExternalEditor | Open in external editor |
+| Default Key | Command              | Description             |
+| ----------- | -------------------- | ----------------------- |
+| Ctrl-R      | Execute              | Execute query           |
+| Esc         | UnfocusEditor        | Unfocus editor          |
+| Ctrl-Space  | OpenInExternalEditor | Open in external editor |
 
 Specific editor for lazysql can be set by `$SQL_EDITOR`.
 
@@ -501,50 +533,50 @@ Specific terminal for opening editor can be set by `$SQL_TERMINAL`
 
 #### Sidebar
 
-| Default Key | Command | Description |
-| --- | --- | --- |
-| s | UnfocusSidebar | Focus table |
-| S | ToggleSidebar | Toggle sidebar |
-| j | MoveDown | Focus next field |
-| k | MoveUp | Focus previous field |
-| g | GotoStart | Focus first field |
-| G | GotoEnd | Focus last field |
-| c | Edit | Edit field |
-| Enter | CommitEdit | Add edit to pending changes |
-| Esc | DiscardEdit | Discard edit |
-| C | SetValue | Toggle value menu (NULL, EMPTY, DEFAULT) |
-| y | Copy | Copy value to clipboard |
+| Default Key | Command        | Description                              |
+| ----------- | -------------- | ---------------------------------------- |
+| s           | UnfocusSidebar | Focus table                              |
+| S           | ToggleSidebar  | Toggle sidebar                           |
+| j           | MoveDown       | Focus next field                         |
+| k           | MoveUp         | Focus previous field                     |
+| g           | GotoStart      | Focus first field                        |
+| G           | GotoEnd        | Focus last field                         |
+| c           | Edit           | Edit field                               |
+| Enter       | CommitEdit     | Add edit to pending changes              |
+| Esc         | DiscardEdit    | Discard edit                             |
+| C           | SetValue       | Toggle value menu (NULL, EMPTY, DEFAULT) |
+| y           | Copy           | Copy value to clipboard                  |
 
 #### Query Preview
 
-| Default Key | Command | Description |
-| --- | --- | --- |
-| Ctrl-S | Save | Execute queries |
-| q | Quit | Quit |
-| y | Copy | Copy query to clipboard |
-| d | Delete | Delete query |
+| Default Key | Command | Description             |
+| ----------- | ------- | ----------------------- |
+| Ctrl-S      | Save    | Execute queries         |
+| q           | Quit    | Quit                    |
+| y           | Copy    | Copy query to clipboard |
+| d           | Delete  | Delete query            |
 
 #### Query History
 
-| Default Key | Command | Description |
-| --- | --- | --- |
-| s | Save | Save query |
-| d | Delete | Delete query |
-| q | Quit | Quit |
-| y | Copy | Copy query to clipboard |
-| / | Search | Search |
-| Ctrl-_ | ToggleQueryHistory | Toggle query history modal |
-| [ | TabPrev | Switch to previous tab |
-| ] | TabNext | Switch to next tab |
+| Default Key | Command            | Description                |
+| ----------- | ------------------ | -------------------------- |
+| s           | Save               | Save query                 |
+| d           | Delete             | Delete query               |
+| q           | Quit               | Quit                       |
+| y           | Copy               | Copy query to clipboard    |
+| /           | Search             | Search                     |
+| Ctrl-_      | ToggleQueryHistory | Toggle query history modal |
+| [           | TabPrev            | Switch to previous tab     |
+| ]           | TabNext            | Switch to next tab         |
 
 #### JSON Viewer
 
-| Default Key | Command | Description |
-| --- | --- | --- |
-| Z | ShowRowJSONViewer | Toggle JSON viewer |
-| z | ShowCellJSONViewer | Toggle JSON viewer |
-| y | Copy | Copy value to clipboard |
-| w | ToggleJSONViewerWrap | Toggle word wrap |
+| Default Key | Command              | Description             |
+| ----------- | -------------------- | ----------------------- |
+| Z           | ShowRowJSONViewer    | Toggle JSON viewer      |
+| z           | ShowCellJSONViewer   | Toggle JSON viewer      |
+| y           | Copy                 | Copy value to clipboard |
+| w           | ToggleJSONViewerWrap | Toggle word wrap        |
 
 ## Example connection URLs
 
@@ -574,13 +606,16 @@ odbc+postgres://user:pass@localhost:port/dbname?option1=
 - [x] Show keybindings on a modal
 - [x] Rewrite row `create`, `update` and `delete` logic
 
-See the [open issues](https://github.com/jorgerojas26/lazysql/issues) for a full list of proposed features (and known issues).
+See the [open issues](https://github.com/jorgerojas26/lazysql/issues) for a full
+list of proposed features (and known issues).
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 ## Clipboard support
 
-We use [atotto/clipboard](https://github.com/atotto/clipboard?tab=readme-ov-file#clipboard-for-go) to copy to clipboard.
+We use
+[atotto/clipboard](https://github.com/atotto/clipboard?tab=readme-ov-file#clipboard-for-go)
+to copy to clipboard.
 
 Platforms:
 
@@ -608,7 +643,8 @@ Distributed under the MIT License. See `LICENSE.txt` for more information.
 
 ## Contact
 
-Jorge Rojas - [LinkedIn](https://www.linkedin.com/in/jorgerojas26/) - jorgeluisrojasb@gmail.com
+Jorge Rojas - [LinkedIn](https://www.linkedin.com/in/jorgerojas26/) -
+jorgeluisrojasb@gmail.com
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/app/keymap.go
+++ b/app/keymap.go
@@ -69,6 +69,8 @@ var Keymaps = KeymapSystem{
 			Bind{Key: Key{Code: tcell.KeyCtrlP}, Cmd: cmd.SearchGlobal, Description: "Global search"},
 			Bind{Key: Key{Code: tcell.KeyCtrlUnderscore}, Cmd: cmd.ToggleQueryHistory, Description: "Toggle query history modal"},
 			Bind{Key: Key{Char: 'T'}, Cmd: cmd.ToggleTree, Description: "Toggle file tree"},
+			Bind{Key: Key{Code: tcell.KeyCtrlL}, Cmd: cmd.TreeWidthIncrease, Description: "Increase tree width"},
+			Bind{Key: Key{Code: tcell.KeyCtrlH}, Cmd: cmd.TreeWidthDecrease, Description: "Decrease tree width"},
 		},
 		ConnectionGroup: {
 			Bind{Key: Key{Char: 'n'}, Cmd: cmd.NewConnection, Description: "Create a new database connection"},

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -75,6 +75,10 @@ const (
 	ShowCellJSONViewer
 	ToggleJSONViewerWrap
 
+	// Tree width
+	TreeWidthIncrease
+	TreeWidthDecrease
+
 	// Connection
 	NewConnection
 	Connect
@@ -226,6 +230,10 @@ func (c Command) String() string {
 		return "ToggleJSONViewerWrap"
 	case ExportCSV:
 		return "ExportCSV"
+	case TreeWidthIncrease:
+		return "TreeWidthIncrease"
+	case TreeWidthDecrease:
+		return "TreeWidthDecrease"
 	}
 
 	return "Unknown"


### PR DESCRIPTION
With the addition of configurable tree width in #267 this adds keyboard shortcuts to dynamically resize tree sidebar width at runtime.

  - Ctrl+l increases tree width by 5 columns
  - Ctrl+h decreases tree width by 5 columns

Width is bounded between 10 and 100 columns and can only be adjusted while the tree view is visible