### PR TITLE
feat: add JSON viewer word wrap setting and toggle keybinding

### DIFF
--- a/app/config.go
+++ b/app/config.go
@@ -26,6 +26,7 @@ func defaultConfig() *Config {
 			SidebarOverlay:               false,
 			MaxQueryHistoryPerConnection: 100,
 			TreeWidth:                    30,
+			JSONViewerWordWrap:           false,
 		},
 	}
 }

--- a/app/keymap.go
+++ b/app/keymap.go
@@ -172,6 +172,7 @@ var Keymaps = KeymapSystem{
 			Bind{Key: Key{Char: 'Z'}, Cmd: cmd.ShowRowJSONViewer, Description: "Toggle JSON viewer"},
 			Bind{Key: Key{Char: 'z'}, Cmd: cmd.ShowCellJSONViewer, Description: "Toggle JSON viewer"},
 			Bind{Key: Key{Char: 'y'}, Cmd: cmd.Copy, Description: "Copy value to clipboard"},
+			Bind{Key: Key{Char: 'w'}, Cmd: cmd.ToggleJSONViewerWrap, Description: "Toggle word wrap"},
 		},
 	},
 }

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -73,6 +73,7 @@ const (
 	ToggleSidebar
 	ShowRowJSONViewer
 	ShowCellJSONViewer
+	ToggleJSONViewerWrap
 
 	// Connection
 	NewConnection
@@ -221,6 +222,8 @@ func (c Command) String() string {
 		return "ShowRowJSONViewer"
 	case ShowCellJSONViewer:
 		return "ShowCellJSONViewer"
+	case ToggleJSONViewerWrap:
+		return "ToggleJSONViewerWrap"
 	case ExportCSV:
 		return "ExportCSV"
 	}

--- a/components/json_viewer.go
+++ b/components/json_viewer.go
@@ -20,13 +20,15 @@ type JSONViewer struct {
 	TextView         *tview.TextView
 	Pages            *tview.Pages
 	primitiveToFocus tview.Primitive
+	wrapEnabled      bool
 }
 
 func NewJSONViewer(pages *tview.Pages) *JSONViewer {
+	wrapEnabled := app.App.Config().JSONViewerWordWrap
 	textView := tview.NewTextView().
 		SetDynamicColors(true).
 		SetScrollable(true).
-		SetWrap(false)
+		SetWrap(wrapEnabled)
 	textView.SetBorder(true).SetTitle(" JSON Viewer ")
 
 	flex := tview.NewFlex().
@@ -38,9 +40,10 @@ func NewJSONViewer(pages *tview.Pages) *JSONViewer {
 		AddItem(nil, 0, 1, false)
 
 	jsonViewer := &JSONViewer{
-		Flex:     flex,
-		TextView: textView,
-		Pages:    pages,
+		Flex:        flex,
+		TextView:    textView,
+		Pages:       pages,
+		wrapEnabled: wrapEnabled,
 	}
 
 	pages.AddPage(pageNameJSONViewer, jsonViewer, true, false)
@@ -57,6 +60,10 @@ func NewJSONViewer(pages *tview.Pages) *JSONViewer {
 			if err != nil {
 				logger.Error("Error copying JSON to clipboard", map[string]any{"error": err.Error()})
 			}
+			return nil
+		} else if command == commands.ToggleJSONViewerWrap {
+			jsonViewer.wrapEnabled = !jsonViewer.wrapEnabled
+			jsonViewer.TextView.SetWrap(jsonViewer.wrapEnabled)
 			return nil
 		}
 		return event

--- a/models/models.go
+++ b/models/models.go
@@ -12,6 +12,7 @@ type AppConfig struct {
 	SidebarOverlay               bool
 	MaxQueryHistoryPerConnection int
 	TreeWidth                    int
+	JSONViewerWordWrap           bool
 }
 
 type Connection struct {


### PR DESCRIPTION
## Summary
- Add `JSONViewerWordWrap` config option to enable word wrap in JSON viewer
- Add `w` keybinding to toggle word wrap while viewing JSON

## Config Usage
```toml
[application]
JSONViewerWordWrap = true
```

## Test Plan
- [ ] Set `JSONViewerWordWrap = true` in config, open JSON viewer - text should wrap
- [ ] Press `w` in JSON viewer to toggle wrap on/off

🤖 Generated with [Claude Code](https://claude.ai/code)