### PR TITLE
feat: add external editor for cell values and Enter keybinding config

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,19 @@ URL = 'postgres://postgres:urlencodedpassword@localhost:5432/foo'
 DefaultPageSize = 300
 DisableSidebar = false
 SidebarOverlay = false
+JSONViewerWordWrap = false
+EnterOpensJSONViewer = false
 ```
+
+### Application settings
+
+| Setting | Default | Description |
+| ------- | ------- | ----------- |
+| DefaultPageSize | 300 | Number of records to fetch per page |
+| DisableSidebar | false | Disable the sidebar |
+| SidebarOverlay | false | Show sidebar as overlay instead of side panel |
+| JSONViewerWordWrap | false | Enable word wrap in JSON viewer |
+| EnterOpensJSONViewer | false | Open JSON viewer when pressing Enter on a cell |
 
 The `ReadOnly` field (optional, defaults to `false`) can be set to `true` to enable read-only mode for a connection. When enabled, all mutation queries (INSERT, UPDATE, DELETE, DROP, etc.) will be blocked.
 
@@ -392,15 +404,20 @@ Note: Undefined environment variables will be replaced with an empty string.
 | o        | Add row                              |
 | /        | Focus the filter input or SQL editor |
 | CTRL + s | Commit changes                       |
+| CTRL + o | Edit cell in external editor         |
 | >        | Next page                            |
 | <        | Previous page                        |
 | K        | Sort ASC                             |
 | J        | Sort DESC                            |
 | H        | Focus tree panel                     |
-| {        | Focus previous tab                   |
-| }        | Focus next tab                       |
+| [        | Focus previous tab                   |
+| ]        | Focus next tab                       |
+| {        | Focus first tab                      |
+| }        | Focus last tab                       |
 | X        | Close current tab                    |
 | R        | Refresh the current table            |
+| z        | Open JSON viewer for cell            |
+| Z        | Open JSON viewer for row             |
 | E        | Export to CSV                        |
 
 ### Tree
@@ -415,14 +432,31 @@ Note: Undefined environment variables will be replaced with an empty string.
 
 ### SQL Editor
 
-| Key          | Action                            |
-| ------------ | --------------------------------- |
-| CTRL + R     | Run the SQL statement             |
-| CTRL + Space | Open external editor (Linux only) |
+| Key          | Action                                       |
+| ------------ | -------------------------------------------- |
+| CTRL + R     | Run the SQL statement                        |
+| CTRL + Space | Open external editor (Linux/macOS only)      |
 
 Specific editor for lazysql can be set by `$SQL_EDITOR`.
 
-Specific terminal for opening editor can be set by `$SQL_TERMINAL`
+### JSON Viewer
+
+| Key | Action           |
+| --- | ---------------- |
+| w   | Toggle word wrap |
+| y   | Copy to clipboard|
+| z/Z | Close viewer     |
+
+The JSON viewer can be opened by pressing `z` (cell) or `Z` (row) on a table cell. If `EnterOpensJSONViewer` is enabled, pressing Enter on a cell will also open the JSON viewer.
+
+### External Editor
+
+The external editor feature (CTRL + Space in SQL Editor, CTRL + o in Table) uses the following environment variables to determine which editor to use:
+
+- SQL Editor: `$SQL_EDITOR` > `$EDITOR` > `$VISUAL` > `vi`
+- Table cells: `$EDITOR` > `$VISUAL` > `vi`
+
+This feature is only available on Linux and macOS.
 
 ## Example connection URLs
 

--- a/app/config.go
+++ b/app/config.go
@@ -27,6 +27,7 @@ func defaultConfig() *Config {
 			MaxQueryHistoryPerConnection: 100,
 			TreeWidth:                    30,
 			JSONViewerWordWrap:           false,
+			EnterOpensJSONViewer:         false,
 		},
 	}
 }

--- a/app/keymap.go
+++ b/app/keymap.go
@@ -133,6 +133,8 @@ var Keymaps = KeymapSystem{
 			Bind{Key: Key{Char: 'z'}, Cmd: cmd.ShowCellJSONViewer, Description: "Toggle JSON viewer for cell"},
 			// Export
 			Bind{Key: Key{Char: 'E'}, Cmd: cmd.ExportCSV, Description: "Export to CSV"},
+			// External editor
+			Bind{Key: Key{Code: tcell.KeyCtrlO}, Cmd: cmd.OpenCellInExternalEditor, Description: "Edit cell in external editor"},
 		},
 		EditorGroup: {
 			Bind{Key: Key{Code: tcell.KeyCtrlR}, Cmd: cmd.Execute, Description: "Execute query"},

--- a/app/keymap.go
+++ b/app/keymap.go
@@ -138,7 +138,7 @@ var Keymaps = KeymapSystem{
 			// Export
 			Bind{Key: Key{Char: 'E'}, Cmd: cmd.ExportCSV, Description: "Export to CSV"},
 			// External editor
-			Bind{Key: Key{Code: tcell.KeyCtrlO}, Cmd: cmd.OpenCellInExternalEditor, Description: "Edit cell in external editor"},
+			Bind{Key: Key{Char: 'e'}, Cmd: cmd.OpenCellInExternalEditor, Description: "Edit cell in external editor"},
 		},
 		EditorGroup: {
 			Bind{Key: Key{Code: tcell.KeyCtrlR}, Cmd: cmd.Execute, Description: "Execute query"},

--- a/commands/commands.go
+++ b/commands/commands.go
@@ -57,6 +57,7 @@ const (
 	Quit
 	Execute
 	OpenInExternalEditor
+	OpenCellInExternalEditor
 	AppendNewRow
 	DuplicateRow
 	SortAsc
@@ -162,6 +163,8 @@ func (c Command) String() string {
 		return "Execute"
 	case OpenInExternalEditor:
 		return "OpenInExternalEditor"
+	case OpenCellInExternalEditor:
+		return "OpenCellInExternalEditor"
 	case AppendNewRow:
 		return "AppendNewRow"
 	case DuplicateRow:

--- a/components/results_table.go
+++ b/components/results_table.go
@@ -1849,7 +1849,7 @@ func openCellInExternalEditor(currentText string) string {
 	editorParts := getCellEditorParts()
 	editorArgs := append(editorParts[1:], tmpFile.Name())
 
-	cmd := exec.Command(editorParts[0], editorArgs...)
+	cmd := exec.Command(editorParts[0], editorArgs...) //nolint:gosec // editor comes from trusted $EDITOR env var
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/components/results_table.go
+++ b/components/results_table.go
@@ -1859,7 +1859,9 @@ func openCellInExternalEditor(currentText string) string {
 
 	if _, err := tmpFile.WriteString(currentText); err != nil {
 		logger.Error("Failed to write to temporary file", map[string]any{"error": err.Error()})
-		tmpFile.Close()
+		if closeErr := tmpFile.Close(); closeErr != nil {
+			logger.Error("Failed to close temporary file", map[string]any{"error": closeErr.Error()})
+		}
 		return currentText
 	}
 

--- a/drivers/postgres.go
+++ b/drivers/postgres.go
@@ -811,7 +811,9 @@ func (db *Postgres) SwitchDatabase(database string) error {
 
 	err = db.Connection.Close()
 	if err != nil {
-		conn.Close()
+		if closeErr := conn.Close(); closeErr != nil {
+			logger.Error("Failed to close postgres connection", map[string]any{"error": closeErr})
+		}
 		return err
 	}
 

--- a/models/models.go
+++ b/models/models.go
@@ -13,6 +13,7 @@ type AppConfig struct {
 	MaxQueryHistoryPerConnection int
 	TreeWidth                    int
 	JSONViewerWordWrap           bool
+	EnterOpensJSONViewer         bool
 }
 
 type Connection struct {


### PR DESCRIPTION
## Summary
- Add `Ctrl+O` keybinding to edit current cell value in external editor (`$EDITOR`, `$VISUAL`, or `vi`)
- Add `EnterOpensJSONViewer` config option to open JSON viewer when pressing Enter on a cell (disabled by default)

## Config Usage
```toml
[application]
EnterOpensJSONViewer = true
```

## Notes
- External editor works on Linux/macOS only (same as SQL editor)
- Changes made in external editor are tracked as pending changes

## Test Plan
- [ ] Focus a cell in the table, press `Ctrl+O` - editor opens with cell content
- [ ] Edit and save - cell updates with new value
- [ ] Verify change appears in pending changes (`Ctrl+S` to preview)
- [ ] Set `EnterOpensJSONViewer = true`, press Enter on cell - JSON viewer opens

🤖 Generated with [Claude Code](https://claude.ai/code)