### PR TITLE
Fix: JSON viewer wraps single-cell content under column name, creating incorrect nesting

### DIFF
--- a/components/json_viewer.go
+++ b/components/json_viewer.go
@@ -87,7 +87,18 @@ func (v *JSONViewer) Show(rowData map[string]string, focus tview.Primitive) {
 		}
 	}
 
-	jsonData, err := json.MarshalIndent(structuredRowData, "", "  ")
+	// For single cell view, show the JSON content directly without wrapping
+	// it under the column name, which would add incorrect extra nesting.
+	var dataToFormat any = structuredRowData
+	if len(structuredRowData) == 1 {
+		for _, value := range structuredRowData {
+			if _, isString := value.(string); !isString {
+				dataToFormat = value
+			}
+		}
+	}
+
+	jsonData, err := json.MarshalIndent(dataToFormat, "", "  ")
 	if err != nil {
 		v.TextView.SetText(fmt.Sprintf("Error: %v", err))
 	} else {

--- a/components/json_viewer_test.go
+++ b/components/json_viewer_test.go
@@ -1,0 +1,119 @@
+package components
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// formatCellJSON simulates the Show() logic for formatting row data into JSON.
+func formatCellJSON(rowData map[string]string) ([]byte, error) {
+	structuredRowData := make(map[string]any)
+
+	for key, value := range rowData {
+		var jsonData any
+		err := json.Unmarshal([]byte(value), &jsonData)
+		if err == nil {
+			structuredRowData[key] = jsonData
+		} else {
+			structuredRowData[key] = value
+		}
+	}
+
+	var dataToFormat any = structuredRowData
+	if len(structuredRowData) == 1 {
+		for _, value := range structuredRowData {
+			if _, isString := value.(string); !isString {
+				dataToFormat = value
+			}
+		}
+	}
+
+	return json.MarshalIndent(dataToFormat, "", "  ")
+}
+
+func TestSingleCellJSONNotWrapped(t *testing.T) {
+	originalJSON := `{"raw":{"SR_NO":1,"AMOUNT":150},"source":"orbii","category":"Expenses"}`
+	columnName := "raw"
+
+	rowData := map[string]string{columnName: originalJSON}
+	result, err := formatCellJSON(rowData)
+	if err != nil {
+		t.Fatalf("Failed to format: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("Failed to parse result: %v", err)
+	}
+
+	// Should have 3 top-level keys: "raw", "source", "category"
+	if len(parsed) != 3 {
+		t.Errorf("Expected 3 top-level keys, got %d: %v", len(parsed), result)
+	}
+	for _, key := range []string{"raw", "source", "category"} {
+		if _, ok := parsed[key]; !ok {
+			t.Errorf("Missing expected top-level key %q", key)
+		}
+	}
+}
+
+func TestSingleCellPlainStringStaysWrapped(t *testing.T) {
+	rowData := map[string]string{"name": "hello world"}
+	result, err := formatCellJSON(rowData)
+	if err != nil {
+		t.Fatalf("Failed to format: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("Failed to parse result: %v", err)
+	}
+
+	// Plain strings should remain wrapped under the column name for context
+	if _, ok := parsed["name"]; !ok {
+		t.Error("Plain string value should remain wrapped under column name")
+	}
+}
+
+func TestMultiColumnRowKeepsAllKeys(t *testing.T) {
+	rowData := map[string]string{
+		"id":   "42",
+		"data": `{"key":"value"}`,
+	}
+	result, err := formatCellJSON(rowData)
+	if err != nil {
+		t.Fatalf("Failed to format: %v", err)
+	}
+
+	var parsed map[string]any
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("Failed to parse result: %v", err)
+	}
+
+	// Multi-column row view should keep all column names
+	if len(parsed) != 2 {
+		t.Errorf("Expected 2 top-level keys, got %d", len(parsed))
+	}
+	if _, ok := parsed["id"]; !ok {
+		t.Error("Missing 'id' key")
+	}
+	if _, ok := parsed["data"]; !ok {
+		t.Error("Missing 'data' key")
+	}
+}
+
+func TestSingleCellJSONArray(t *testing.T) {
+	rowData := map[string]string{"items": `[1, 2, 3]`}
+	result, err := formatCellJSON(rowData)
+	if err != nil {
+		t.Fatalf("Failed to format: %v", err)
+	}
+
+	var parsed []any
+	if err := json.Unmarshal(result, &parsed); err != nil {
+		t.Fatalf("Single cell JSON array should be shown directly: %v", err)
+	}
+	if len(parsed) != 3 {
+		t.Errorf("Expected 3 array elements, got %d", len(parsed))
+	}
+}


### PR DESCRIPTION
# Fix: JSON viewer wraps single-cell content under column name, creating incorrect nesting

> **Disclaimer:** I'm a newbie Go developer and this fix was AI-assisted. That said, I tested it manually and it works as described.

## Problem

When viewing a JSON cell using the cell viewer (`z` key), the JSON content is wrapped inside an extra object keyed by the column name. This adds a false nesting level that does not exist in the actual data.

If the column name happens to match a key inside the JSON (e.g. a column named `metadata` containing a `"metadata"` key), the output becomes especially confusing with duplicate keys at different depths.

## How to reproduce

1. Create a MySQL table with a JSON column:
   ```sql
   CREATE TABLE test_json (
     id INT PRIMARY KEY AUTO_INCREMENT,
     data JSON
   );
   INSERT INTO test_json (data) VALUES ('{"name": "Alice", "address": {"city": "NYC"}}');
   ```
2. Open the table in lazysql
3. Select the `data` cell and press `z` (ShowCellJSONViewer)

### Expected output

The JSON content displayed as-is:

```
{
  "address": {
    "city": "NYC"
  },
  "name": "Alice"
}
```

### Actual output (before fix)

The JSON wrapped under the column name `"data"`:

```
{
  "data": {              <-- extra wrapper (column name)
    "address": {
      "city": "NYC"
    },
    "name": "Alice"
  }
}
```

### Worst case: column name collides with a JSON key

Given a column named `raw` storing:
```json
{"raw": {"amount": 150}, "source": "api"}
```

The viewer rendered:
```
{
  "raw": {               <-- column name wrapper
    "raw": {             <-- actual JSON key
      "amount": 150
    },
    "source": "api"
  }
}
```

This is the scenario reported in the bug.

## Data flow diagram

```
handleShowJSONViewer (results_table.go)
  |
  |  cell view: rowData = {"<column_name>": "<json_string>"}
  |  row view:  rowData = {"col1": "val1", "col2": "val2", ...}
  v
Show (json_viewer.go)
  |
  |  unmarshal each value that is valid JSON
  |  structuredRowData = {"<column_name>": <parsed_object>}
  |
  |  BEFORE FIX: always format structuredRowData as-is
  |    -> single cell gets extra wrapper level
  |
  |  AFTER FIX: if single entry and value is parsed JSON (not plain string),
  |    unwrap it and format the parsed value directly
  |
  v
json.MarshalIndent -> colorizeJSON -> display
```

## Fix

In `json_viewer.go`, after building `structuredRowData`, detect the single-cell case and unwrap:

```go
var dataToFormat any = structuredRowData
if len(structuredRowData) == 1 {
    for _, value := range structuredRowData {
        if _, isString := value.(string); !isString {
            dataToFormat = value
        }
    }
}

jsonData, err := json.MarshalIndent(dataToFormat, "", "  ")
```

### Behavior matrix

| Scenario | Before | After |
|---|---|---|
| Single cell, valid JSON object/array | Wrapped under column name | Shown directly |
| Single cell, plain text (not JSON) | Wrapped under column name | Wrapped under column name (unchanged) |
| Row view (multiple columns) | All columns shown with names | All columns shown with names (unchanged) |

## Tests added

- `TestSingleCellJSONNotWrapped` — JSON object shown directly without column wrapper
- `TestSingleCellPlainStringStaysWrapped` — plain text keeps column name for context
- `TestMultiColumnRowKeepsAllKeys` — row view preserves all column names
- `TestSingleCellJSONArray` — JSON array shown directly without wrapper
