### PR TITLE
feat: add MySQL mTLS support via TLSCert, TLSKey, TLSCA config fields

### DIFF
--- a/components/arg_connection.go
+++ b/components/arg_connection.go
@@ -42,7 +42,7 @@ func InitFromArg(connectionString string, readOnly bool) error {
 		return fmt.Errorf("could not handle database driver %s", connection.Provider)
 	}
 
-	err = newDBDriver.Connect(connection.URL)
+	err = newDBDriver.Connect(connection)
 	if err != nil {
 		return fmt.Errorf("could not connect to database %s: %s", connectionString, err)
 	}

--- a/components/connection_form.go
+++ b/components/connection_form.go
@@ -188,7 +188,7 @@ func (form *ConnectionForm) testConnection(connectionString string) {
 		db = &drivers.MSSQL{}
 	}
 
-	err = db.TestConnection(connectionString)
+	err = db.TestConnection(models.Connection{URL: connectionString, Provider: parsed.Driver})
 
 	if err != nil {
 		form.StatusText.SetText(err.Error()).SetTextStyle(tcell.StyleDefault.Foreground(tcell.ColorRed))

--- a/components/connection_selection.go
+++ b/components/connection_selection.go
@@ -245,7 +245,7 @@ func (cs *ConnectionSelection) Connect(connection models.Connection) *tview.Appl
 		return App.Draw()
 	}
 
-	err := newDBDriver.Connect(connection.URL)
+	err := newDBDriver.Connect(connection)
 	if err != nil {
 		cs.StatusText.SetText(err.Error()).SetTextStyle(tcell.StyleDefault.Foreground(tcell.ColorRed))
 		return App.Draw()

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -5,8 +5,8 @@ import (
 )
 
 type Driver interface {
-	Connect(urlstr string) error
-	TestConnection(urlstr string) error
+	Connect(connection models.Connection) error
+	TestConnection(connection models.Connection) error
 	GetDatabases() ([]string, error)
 	GetTables(database string) (map[string][]string, error)
 	GetTableColumns(database, table string) ([][]string, error)

--- a/drivers/mssqql.go
+++ b/drivers/mssqql.go
@@ -52,12 +52,12 @@ func mssqlGUIDToUUID(dbBytes []byte) (uuid.UUID, error) {
 	return uuid.FromBytes(b)
 }
 
-func (db *MSSQL) TestConnection(urlstr string) error {
-	return db.Connect(urlstr)
+func (db *MSSQL) TestConnection(connection models.Connection) error {
+	return db.Connect(connection)
 }
 
-func (db *MSSQL) Connect(urlstr string) error {
-	if urlstr == "" {
+func (db *MSSQL) Connect(connection models.Connection) error {
+	if connection.URL == "" {
 		return errors.New("url string can not be empty")
 	}
 
@@ -65,7 +65,7 @@ func (db *MSSQL) Connect(urlstr string) error {
 
 	var err error
 
-	db.Connection, err = dburl.Open(urlstr)
+	db.Connection, err = dburl.Open(connection.URL)
 	if err != nil {
 		return err
 	}

--- a/drivers/mysql.go
+++ b/drivers/mysql.go
@@ -1,12 +1,16 @@
 package drivers
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"database/sql"
 	"errors"
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 
+	"github.com/go-sql-driver/mysql"
 	"github.com/xo/dburl"
 
 	"github.com/jorgerojas26/lazysql/models"
@@ -17,14 +21,61 @@ type MySQL struct {
 	Provider   string
 }
 
-func (db *MySQL) TestConnection(urlstr string) (err error) {
-	return db.Connect(urlstr)
+func (db *MySQL) TestConnection(connection models.Connection) (err error) {
+	return db.Connect(connection)
 }
 
-func (db *MySQL) Connect(urlstr string) (err error) {
+func (db *MySQL) Connect(connection models.Connection) (err error) {
 	db.SetProvider(DriverMySQL)
 
-	db.Connection, err = dburl.Open(urlstr)
+	var tlsConfigName string
+
+	if connection.TLSCert != "" || connection.TLSKey != "" || connection.TLSCA != "" {
+		tlsConfigName = "custom-" + connection.Name
+
+		tlsCfg := &tls.Config{
+			InsecureSkipVerify: connection.TLSSkipVerify,
+		}
+
+		if connection.TLSCA != "" {
+			caCert, err := os.ReadFile(connection.TLSCA)
+			if err != nil {
+				return fmt.Errorf("failed to read TLS CA file: %w", err)
+			}
+			caCertPool := x509.NewCertPool()
+			caCertPool.AppendCertsFromPEM(caCert)
+			tlsCfg.RootCAs = caCertPool
+		}
+
+		if connection.TLSCert != "" && connection.TLSKey != "" {
+			cert, err := tls.LoadX509KeyPair(connection.TLSCert, connection.TLSKey)
+			if err != nil {
+				return fmt.Errorf("failed to load TLS key pair: %w", err)
+			}
+			tlsCfg.Certificates = []tls.Certificate{cert}
+		}
+
+		mysql.DeregisterTLSConfig(tlsConfigName)
+		if err := mysql.RegisterTLSConfig(tlsConfigName, tlsCfg); err != nil {
+			return fmt.Errorf("failed to register TLS config: %w", err)
+		}
+	}
+
+	parsedURL, err := dburl.Parse(connection.URL)
+	if err != nil {
+		return fmt.Errorf("failed to parse connection URL: %w", err)
+	}
+
+	dsn := parsedURL.DSN
+	if tlsConfigName != "" {
+		if strings.Contains(dsn, "?") {
+			dsn += "&tls=" + tlsConfigName
+		} else {
+			dsn += "?tls=" + tlsConfigName
+		}
+	}
+
+	db.Connection, err = sql.Open("mysql", dsn)
 	if err != nil {
 		return err
 	}

--- a/drivers/postgres.go
+++ b/drivers/postgres.go
@@ -27,14 +27,14 @@ const (
 	defaultPort = "5432"
 )
 
-func (db *Postgres) TestConnection(urlstr string) error {
-	return db.Connect(urlstr)
+func (db *Postgres) TestConnection(connection models.Connection) error {
+	return db.Connect(connection)
 }
 
-func (db *Postgres) Connect(urlstr string) error {
+func (db *Postgres) Connect(conn models.Connection) error {
 	db.SetProvider(DriverPostgres)
 
-	connection, err := dburl.Open(urlstr)
+	connection, err := dburl.Open(conn.URL)
 	if err != nil {
 		return err
 	}
@@ -46,7 +46,7 @@ func (db *Postgres) Connect(urlstr string) error {
 		return err
 	}
 
-	db.Urlstr = urlstr
+	db.Urlstr = conn.URL
 
 	// Get the current database.
 	rows := db.Connection.QueryRow("SELECT current_database();")

--- a/drivers/sqlite.go
+++ b/drivers/sqlite.go
@@ -14,14 +14,14 @@ type SQLite struct {
 	Provider   string
 }
 
-func (db *SQLite) TestConnection(urlstr string) (err error) {
-	return db.Connect(urlstr)
+func (db *SQLite) TestConnection(connection models.Connection) (err error) {
+	return db.Connect(connection)
 }
 
-func (db *SQLite) Connect(urlstr string) (err error) {
+func (db *SQLite) Connect(connection models.Connection) (err error) {
 	db.SetProvider(DriverSqlite)
 
-	db.Connection, err = sql.Open("sqlite", urlstr)
+	db.Connection, err = sql.Open("sqlite", connection.URL)
 	if err != nil {
 		return err
 	}

--- a/models/models.go
+++ b/models/models.go
@@ -37,6 +37,13 @@ type Connection struct {
 	Schemas []string
 
 	Commands []*Command
+
+	// TLS certificate paths for mTLS connections (MySQL only).
+	// When set, a custom TLS config is registered and used in the DSN.
+	TLSCert       string `toml:"TLSCert,omitempty"`
+	TLSKey        string `toml:"TLSKey,omitempty"`
+	TLSCA         string `toml:"TLSCA,omitempty"`
+	TLSSkipVerify bool   `toml:"TLSSkipVerify,omitempty"`
 }
 
 type KeymapConfig map[string]map[string]string


### PR DESCRIPTION
Adds optional `TLSCert`, `TLSKey`, `TLSCA` fields to the database config for MySQL mTLS connections.

When set, loads the certs and registers a `tls.Config` with `go-sql-driver/mysql` before connecting. Existing `tls=` URL parameters still work when no cert fields are set.

```toml
[[database]]
Name = 'production'
Provider = 'mysql'
URL = 'mysql://user:pass@host:3306/mydb'
TLSCert = '/path/to/client-cert.pem'
TLSKey = '/path/to/client-key.pem'
TLSCA = '/path/to/ca.pem'
```