### PR TITLE
fix(results_table): guard GetPrimaryKeyValue against out-of-range rowIndex

### DIFF
--- a/components/results_table.go
+++ b/components/results_table.go
@@ -1368,9 +1368,19 @@ func (table *ResultsTable) GetPrimaryKeyValue(rowIndex int) []models.PrimaryKeyI
 
 	if len(primaryKeyColumnNames) == 0 {
 		allRecords := table.GetRecords()
+		// Unsaved-new-row deletions shrink the record slice while the
+		// caller still passes the original rowIndex; without these
+		// guards lazysql panicked with 'index out of range' instead of
+		// no-op'ing the second delete.
+		if len(allRecords) == 0 || rowIndex < 0 || rowIndex >= len(allRecords) {
+			return info
+		}
 		columns := allRecords[0]
 		row := allRecords[rowIndex]
 		for i, colName := range columns {
+			if i >= len(row) {
+				break
+			}
 			info = append(info, models.PrimaryKeyInfo{Name: colName, Value: row[i]})
 		}
 		return info
@@ -1379,7 +1389,14 @@ func (table *ResultsTable) GetPrimaryKeyValue(rowIndex int) []models.PrimaryKeyI
 	for _, primaryKeyColumnName := range primaryKeyColumnNames {
 		columnIndex := table.GetColumnIndexByName(primaryKeyColumnName)
 		records := table.GetRecords()
-		primaryKeyValue := records[rowIndex][columnIndex]
+		if rowIndex < 0 || rowIndex >= len(records) {
+			continue
+		}
+		row := records[rowIndex]
+		if columnIndex < 0 || columnIndex >= len(row) {
+			continue
+		}
+		primaryKeyValue := row[columnIndex]
 
 		info = append(info, models.PrimaryKeyInfo{Name: primaryKeyColumnName, Value: primaryKeyValue})
 	}


### PR DESCRIPTION
Fixes jorgerojas26/lazysql#294.

## Problem

`GetPrimaryKeyValue` indexed `records[rowIndex][columnIndex]` directly. When a user queued two unsaved inserts and then deleted them one after the other, the first delete shrank the underlying record slice but the second delete still passed the original `rowIndex`, so the deref panicked and crashed lazysql:

```
panic: runtime error: index out of range [1] with length 1
components.(*ResultsTable).GetPrimaryKeyValue results_table.go:1326
components.(*ResultsTable).AppendNewChange results_table.go:1229
components.(*ResultsTable).tableInputCapture results_table.go:496
```

## Fix

Bounds-check `rowIndex` against `len(records)` in both branches (primary-keyless and primary-keyed), and bounds-check the column index against the row width. Return the info slice accumulated so far (or empty) instead of panicking; the caller already treats a missing primary-key slice as a no-op, which is the right behavior for a row that no longer exists.

## Test

`go test ./components/...` passes locally.