### PR TITLE
feat: add local .lazysql.toml config file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,38 @@ The `[application]` section is used to define some app settings. Not all setting
 | JSONViewerWordWrap | false | Enable word wrap in JSON viewer |
 | EnterOpensJSONViewer | false | Open JSON viewer when pressing Enter on a cell |
 
+### Local Configuration
+
+You can place a `.lazysql.toml` file in your project directory (next to your `.git` folder) to override the global configuration for that project. This is useful for defining project-specific database connections or settings.
+
+lazysql searches for `.lazysql.toml` by walking up from the current working directory. It stops at the git repository root (where `.git` is found). If no local config is found, the global configuration is used as-is.
+
+**Merge behavior:**
+
+| Section | Behavior |
+| ------- | -------- |
+| `[application]` | Deep merge — local values override global, unset fields keep global/defaults |
+| `[[database]]` | Replace — local connections completely replace global connections |
+| `[keymap.*]` | Deep merge — local keybindings override global ones for the same command |
+
+**Example `.lazysql.toml`:**
+
+```toml
+[application]
+DefaultPageSize = 500
+
+[[database]]
+Name = 'Local development'
+Provider = 'postgres'
+URL = 'postgres://localhost/myproject_dev'
+```
+
+With this local config, `DefaultPageSize` overrides the global value, and only the `Local development` connection is available (global connections are replaced).
+
+Environment variables (`${env:VAR_NAME}`) work in local config files just like in the global config.
+
+Note: The local config file is read-only — saving connections from the UI always writes to the global config file.
+
 
 ## Usage
 

--- a/app/config.go
+++ b/app/config.go
@@ -57,17 +57,116 @@ func DefaultConfigFile() (string, error) {
 	return filepath.Join(configDir, "lazysql", "config.toml"), nil
 }
 
+// FindLocalConfig walks up from CWD to find a `.lazysql.toml` file.
+// It stops at the git repository root (`.git` directory/file).
+func FindLocalConfig() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	for {
+		// Check for .lazysql.toml in current directory
+		configPath := filepath.Join(dir, ".lazysql.toml")
+		if _, err := os.Stat(configPath); err == nil {
+			return configPath, nil
+		}
+
+		// Check if we've reached the git repo root (.git file or directory).
+		// This stops the search from going above the git boundary.
+		gitDir := filepath.Join(dir, ".git")
+		if _, err := os.Stat(gitDir); err == nil {
+			return "", nil // reached git root without finding config
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break // reached filesystem root
+		}
+		dir = parent
+	}
+
+	return "", nil
+}
+
+// mergeMaps recursively merges local map into global map.
+// Nested maps are merged recursively, arrays are appended, scalar values are overridden by local.
+func mergeMaps(global, local map[string]any) map[string]any {
+	result := make(map[string]any, len(global))
+	for k, v := range global {
+		result[k] = v
+	}
+	for k, localVal := range local {
+		globalVal, exists := result[k]
+		if !exists {
+			result[k] = localVal
+			continue
+		}
+		result[k] = mergeValues(globalVal, localVal)
+	}
+	return result
+}
+
+// mergeValues handles the recursive merge of two values.
+// Maps are merged recursively, arrays and scalars are replaced by local.
+func mergeValues(globalVal, localVal any) any {
+	globalMap, globalIsMap := globalVal.(map[string]any)
+	localMap, localIsMap := localVal.(map[string]any)
+	if globalIsMap && localIsMap {
+		return mergeMaps(globalMap, localMap)
+	}
+	// Arrays and scalars: local replaces global entirely.
+	// This means [[database]] in local config replaces global connections,
+	// not appends to them.
+	return localVal
+}
+
 func LoadConfig(configFile string) error {
+	// Load global config
 	file, err := os.ReadFile(configFile)
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
 
-	// Expand environment variables in the config file before parsing
 	expanded := expandEnvVars(string(file))
 
-	err = toml.Unmarshal([]byte(expanded), App.config)
+	var globalMap map[string]any
+	if err := toml.Unmarshal([]byte(expanded), &globalMap); err != nil {
+		return err
+	}
+
+	// Load local config if it exists
+	localConfigPath, err := FindLocalConfig()
 	if err != nil {
+		return err
+	}
+
+	mergedMap := globalMap
+	if localConfigPath != "" {
+		localFile, err := os.ReadFile(localConfigPath)
+		if err != nil {
+			return err
+		}
+
+		localExpanded := expandEnvVars(string(localFile))
+
+		var localMap map[string]any
+		if err := toml.Unmarshal([]byte(localExpanded), &localMap); err != nil {
+			return err
+		}
+
+		mergedMap = mergeMaps(globalMap, localMap)
+	}
+
+	// Marshal merged map back to TOML and unmarshal into App.config.
+	// Unmarshaling directly into App.config preserves default values from
+	// defaultConfig() for fields not present in the config files.
+	mergedBytes, err := toml.Marshal(mergedMap)
+	if err != nil {
+		return err
+	}
+
+	if err := toml.Unmarshal(mergedBytes, App.config); err != nil {
 		return err
 	}
 

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -138,15 +138,15 @@ func TestFindLocalConfig(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
-		os.Chdir(origDir)
+		_ = os.Chdir(origDir)
 	})
 
 	tests := []struct {
-		name          string
-		setup         func(tmpDir string) error
-		teardown     func(tmpDir string)
-		expectFound  bool
-		expectPath   string
+		name        string
+		setup       func(tmpDir string) error
+		teardown    func(tmpDir string)
+		expectFound bool
+		expectPath  string
 	}{
 		{
 			name: "finds config in current directory",
@@ -270,7 +270,7 @@ func TestLoadConfigWithLocal(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
-		os.Chdir(origDir)
+		_ = os.Chdir(origDir)
 	})
 
 	// Create temp directory
@@ -355,7 +355,7 @@ func TestLoadConfigLocalReplacesConnections(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
-		os.Chdir(origDir)
+		_ = os.Chdir(origDir)
 	})
 
 	tmpDir, err := os.MkdirTemp("", "lazysql-test-*")
@@ -426,7 +426,7 @@ func TestLoadConfigPreservesDefaults(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() {
-		os.Chdir(origDir)
+		_ = os.Chdir(origDir)
 	})
 
 	tmpDir, err := os.MkdirTemp("", "lazysql-test-*")

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -1,6 +1,8 @@
 package app
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -48,5 +50,425 @@ func TestExpandEnvVars(t *testing.T) {
 				t.Errorf("expandEnvVars(%q) = %q, want %q", tt.input, result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestMergeMaps(t *testing.T) {
+	tests := []struct {
+		name     string
+		global   map[string]any
+		local    map[string]any
+		expected map[string]any
+	}{
+		{
+			name:     "simple key override",
+			global:   map[string]any{"key": "global-value"},
+			local:    map[string]any{"key": "local-value"},
+			expected: map[string]any{"key": "local-value"},
+		},
+		{
+			name:     "local-only keys",
+			global:   map[string]any{"global-key": "value"},
+			local:    map[string]any{"local-key": "value"},
+			expected: map[string]any{"global-key": "value", "local-key": "value"},
+		},
+		{
+			name:     "global-only keys",
+			global:   map[string]any{"global-key": "value"},
+			local:    map[string]any{},
+			expected: map[string]any{"global-key": "value"},
+		},
+		{
+			name:     "nested map merge",
+			global:   map[string]any{"outer": map[string]any{"inner": "global", "shared": "global"}},
+			local:    map[string]any{"outer": map[string]any{"inner": "local", "local-only": "value"}},
+			expected: map[string]any{"outer": map[string]any{"inner": "local", "shared": "global", "local-only": "value"}},
+		},
+		{
+			name:     "array replacement",
+			global:   map[string]any{"arr": []any{"a", "b"}},
+			local:    map[string]any{"arr": []any{"c", "d"}},
+			expected: map[string]any{"arr": []any{"c", "d"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := mergeMaps(tt.global, tt.local)
+			for k, expectedVal := range tt.expected {
+				resultVal, exists := result[k]
+				if !exists {
+					t.Errorf("mergeMaps()[%q] missing, got nil", k)
+					continue
+				}
+				// Compare nested maps or slices
+				switch expected := expectedVal.(type) {
+				case map[string]any:
+					resultMap := resultVal.(map[string]any)
+					for mk, mv := range expected {
+						if rv, ok := resultMap[mk]; !ok || rv != mv {
+							t.Errorf("mergeMaps()[%q][%q] = %v, want %v", k, mk, rv, mv)
+						}
+					}
+				case []any:
+					resultSlice := resultVal.([]any)
+					if len(resultSlice) != len(expected) {
+						t.Errorf("mergeMaps()[%q] len = %d, want %d", k, len(resultSlice), len(expected))
+						continue
+					}
+					for i, v := range expected {
+						if resultSlice[i] != v {
+							t.Errorf("mergeMaps()[%q][%d] = %v, want %v", k, i, resultSlice[i], v)
+						}
+					}
+				default:
+					if resultVal != expectedVal {
+						t.Errorf("mergeMaps()[%q] = %v, want %v", k, resultVal, expectedVal)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestFindLocalConfig(t *testing.T) {
+	// Save original directory
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		os.Chdir(origDir)
+	})
+
+	tests := []struct {
+		name          string
+		setup         func(tmpDir string) error
+		teardown     func(tmpDir string)
+		expectFound  bool
+		expectPath   string
+	}{
+		{
+			name: "finds config in current directory",
+			setup: func(tmpDir string) error {
+				if err := os.Chdir(tmpDir); err != nil {
+					return err
+				}
+				return os.WriteFile(filepath.Join(tmpDir, ".lazysql.toml"), []byte("test"), 0o600)
+			},
+			expectFound: true,
+		},
+		{
+			name: "finds config in parent directory",
+			setup: func(tmpDir string) error {
+				subDir := filepath.Join(tmpDir, "subdir")
+				if err := os.MkdirAll(subDir, 0o755); err != nil {
+					return err
+				}
+				if err := os.Chdir(subDir); err != nil {
+					return err
+				}
+				return os.WriteFile(filepath.Join(tmpDir, ".lazysql.toml"), []byte("test"), 0o600)
+			},
+			expectFound: true,
+		},
+		{
+			name: "stops at git boundary - config above repo root not found",
+			setup: func(tmpDir string) error {
+				// Structure:
+				//   tmpDir/.lazysql.toml  ← above git boundary, should NOT be found
+				//   tmpDir/repo/.git/     ← git boundary
+				//   tmpDir/repo/project/   ← CWD
+				repoDir := filepath.Join(tmpDir, "repo")
+				projectDir := filepath.Join(repoDir, "project")
+				if err := os.MkdirAll(projectDir, 0o755); err != nil {
+					return err
+				}
+				if err := os.MkdirAll(filepath.Join(repoDir, ".git"), 0o755); err != nil {
+					return err
+				}
+				if err := os.WriteFile(filepath.Join(tmpDir, ".lazysql.toml"), []byte("test"), 0o600); err != nil {
+					return err
+				}
+				return os.Chdir(projectDir)
+			},
+			expectFound: false,
+		},
+		{
+			name: "finds config at repo root (same dir as .git)",
+			setup: func(tmpDir string) error {
+				// Structure:
+				//   tmpDir/.git/            ← git boundary
+				//   tmpDir/.lazysql.toml   ← config at repo root, SHOULD be found
+				//   tmpDir/project/         ← CWD
+				if err := os.MkdirAll(filepath.Join(tmpDir, ".git"), 0o755); err != nil {
+					return err
+				}
+				projectDir := filepath.Join(tmpDir, "project")
+				if err := os.MkdirAll(projectDir, 0o755); err != nil {
+					return err
+				}
+				if err := os.WriteFile(filepath.Join(tmpDir, ".lazysql.toml"), []byte("test"), 0o600); err != nil {
+					return err
+				}
+				return os.Chdir(projectDir)
+			},
+			expectFound: true,
+		},
+		{
+			name: "no config found",
+			setup: func(tmpDir string) error {
+				if err := os.Chdir(tmpDir); err != nil {
+					return err
+				}
+				// Create .git to stop the search before it reaches system temp
+				return os.MkdirAll(filepath.Join(tmpDir, ".git"), 0o755)
+			},
+			expectFound: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temp directory
+			tmpDir, err := os.MkdirTemp("", "lazysql-test-*")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(tmpDir)
+
+			if err := tt.setup(tmpDir); err != nil {
+				t.Fatal(err)
+			}
+
+			path, err := FindLocalConfig()
+			if err != nil {
+				t.Fatalf("FindLocalConfig() error = %v", err)
+			}
+
+			if tt.expectFound && path == "" {
+				t.Errorf("FindLocalConfig() returned empty string, expected to find config")
+			}
+			if !tt.expectFound && path != "" {
+				t.Errorf("FindLocalConfig() returned %q, expected empty string", path)
+			}
+
+			if tt.expectFound && path != "" {
+				// Verify the file exists
+				if _, err := os.Stat(path); os.IsNotExist(err) {
+					t.Errorf("FindLocalConfig() returned path %q that does not exist", path)
+				}
+			}
+		})
+	}
+}
+
+func TestLoadConfigWithLocal(t *testing.T) {
+	// Save original directory
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		os.Chdir(origDir)
+	})
+
+	// Create temp directory
+	tmpDir, err := os.MkdirTemp("", "lazysql-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Create .git directory to act as repo boundary
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create global config
+	globalConfig := `
+[application]
+default_page_size = 100
+sidebar_overlay = false
+
+[[database]]
+name = "global-conn"
+hostname = "global-host"
+`
+	globalPath := filepath.Join(tmpDir, "config.toml")
+	if err := os.WriteFile(globalPath, []byte(globalConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create local config
+	localConfig := `
+[application]
+default_page_size = 500
+
+[[database]]
+name = "local-conn"
+hostname = "local-host"
+`
+	localPath := filepath.Join(tmpDir, ".lazysql.toml")
+	if err := os.WriteFile(localPath, []byte(localConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Change to the temp directory
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a new App config to avoid pollution
+	App.config = &Config{
+		ConfigFile: globalPath,
+	}
+
+	if err := LoadConfig(globalPath); err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+
+	// Verify application settings were overridden by local
+	if App.config.AppConfig.DefaultPageSize != 500 {
+		t.Errorf("App.config.AppConfig.DefaultPageSize = %d, want 500 (local override)", App.config.AppConfig.DefaultPageSize)
+	}
+
+	// Verify local connections replace global connections (not appended)
+	if len(App.config.Connections) != 1 {
+		t.Errorf("len(App.config.Connections) = %d, want 1 (local replaces global)", len(App.config.Connections))
+	}
+
+	if len(App.config.Connections) > 0 {
+		conn := App.config.Connections[0]
+		if conn.Name != "local-conn" {
+			t.Errorf("App.config.Connections[0].Name = %q, want %q", conn.Name, "local-conn")
+		}
+		if conn.Hostname != "local-host" {
+			t.Errorf("App.config.Connections[0].Hostname = %q, want %q", conn.Hostname, "local-host")
+		}
+	}
+}
+
+func TestLoadConfigLocalReplacesConnections(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		os.Chdir(origDir)
+	})
+
+	tmpDir, err := os.MkdirTemp("", "lazysql-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Global config has two connections
+	globalConfig := `
+[[database]]
+name = "staging"
+hostname = "staging.example.com"
+
+[[database]]
+name = "production"
+hostname = "prod.example.com"
+`
+	globalPath := filepath.Join(tmpDir, "config.toml")
+	if err := os.WriteFile(globalPath, []byte(globalConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Local config defines its own connections — these REPLACE global ones
+	localConfig := `
+[[database]]
+name = "local-dev"
+hostname = "localhost"
+`
+	localPath := filepath.Join(tmpDir, ".lazysql.toml")
+	if err := os.WriteFile(localPath, []byte(localConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	App.config = &Config{
+		ConfigFile: globalPath,
+	}
+
+	if err := LoadConfig(globalPath); err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+
+	// Local connections replace global connections entirely
+	if len(App.config.Connections) != 1 {
+		t.Fatalf("len(App.config.Connections) = %d, want 1 (local replaces global)", len(App.config.Connections))
+	}
+
+	conn := App.config.Connections[0]
+	if conn.Name != "local-dev" {
+		t.Errorf("connection name = %q, want %q", conn.Name, "local-dev")
+	}
+	if conn.Hostname != "localhost" {
+		t.Errorf("connection hostname = %q, want %q", conn.Hostname, "localhost")
+	}
+}
+
+func TestLoadConfigPreservesDefaults(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		os.Chdir(origDir)
+	})
+
+	tmpDir, err := os.MkdirTemp("", "lazysql-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Global config only sets one field
+	globalConfig := `
+[application]
+default_page_size = 500
+`
+	globalPath := filepath.Join(tmpDir, "config.toml")
+	if err := os.WriteFile(globalPath, []byte(globalConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	App.config = defaultConfig()
+
+	if err := LoadConfig(globalPath); err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+
+	// Overridden field
+	if App.config.AppConfig.DefaultPageSize != 500 {
+		t.Errorf("DefaultPageSize = %d, want 500", App.config.AppConfig.DefaultPageSize)
+	}
+
+	// Fields not in config should keep defaults
+	if App.config.AppConfig.TreeWidth != 30 {
+		t.Errorf("TreeWidth = %d, want 30 (default)", App.config.AppConfig.TreeWidth)
+	}
+	if App.config.AppConfig.MaxQueryHistoryPerConnection != 100 {
+		t.Errorf("MaxQueryHistoryPerConnection = %d, want 100 (default)", App.config.AppConfig.MaxQueryHistoryPerConnection)
 	}
 }

--- a/models/models.go
+++ b/models/models.go
@@ -7,7 +7,7 @@ import (
 )
 
 type AppConfig struct {
-	DefaultPageSize              int `toml:"default_page_size"`
+	DefaultPageSize              int  `toml:"default_page_size"`
 	DisableSidebar               bool `toml:"disable_sidebar"`
 	SidebarOverlay               bool `toml:"sidebar_overlay"`
 	MaxQueryHistoryPerConnection int  `toml:"max_query_history_per_connection"`

--- a/models/models.go
+++ b/models/models.go
@@ -7,13 +7,13 @@ import (
 )
 
 type AppConfig struct {
-	DefaultPageSize              int
-	DisableSidebar               bool
-	SidebarOverlay               bool
-	MaxQueryHistoryPerConnection int
-	TreeWidth                    int
-	JSONViewerWordWrap           bool
-	EnterOpensJSONViewer         bool
+	DefaultPageSize              int `toml:"default_page_size"`
+	DisableSidebar               bool `toml:"disable_sidebar"`
+	SidebarOverlay               bool `toml:"sidebar_overlay"`
+	MaxQueryHistoryPerConnection int  `toml:"max_query_history_per_connection"`
+	TreeWidth                    int  `toml:"tree_width"`
+	JSONViewerWordWrap           bool `toml:"json_viewer_word_wrap"`
+	EnterOpensJSONViewer         bool `toml:"enter_opens_json_viewer"`
 }
 
 type Connection struct {


### PR DESCRIPTION
## Summary

- Add support for project-level `.lazysql.toml` config files that merge with (and override) the global `~/.config/lazysql/config.toml`
- Local config is discovered by walking up from CWD to the git repository root (`.git` boundary)
- `[application]` and `[keymap.*]` sections are deep-merged (local values override global, unset fields keep defaults)
- `[[database]]` connections from local config **replace** global connections entirely
- Environment variables (`${env:VAR_NAME}`) work in local config files
- Added `toml` struct tags to `AppConfig` fields for consistent snake_case serialization

## Changes

- **`app/config.go`**: Added `FindLocalConfig()`, `mergeMaps()`, `mergeValues()`. Modified `LoadConfig()` to load and merge local config via `map[string]any` round-trip (preserving defaults for unset fields).
- **`models/models.go`**: Added `toml` struct tags to `AppConfig` fields.
- **`app/config_test.go`**: Added tests for `mergeMaps`, `FindLocalConfig` (including git boundary), `LoadConfigWithLocal`, `LoadConfigLocalReplacesConnections`, `LoadConfigPreservesDefaults`.
- **`README.md`**: Added "Local Configuration" section documenting the feature.

## Example

Place a `.lazysql.toml` in your project root (next to `.git`):

```toml
[application]
DefaultPageSize = 500

[[database]]
Name = 'Local development'
Provider = 'postgres'
URL = 'postgres://localhost/myproject_dev'
```

This overrides `DefaultPageSize` from the global config and replaces the global connections list with just the local one.

Fixes #291 