### PR TITLE
fix(Postgres): Preserve Postgres connection options when switching databases

### DIFF
--- a/drivers/postgres.go
+++ b/drivers/postgres.go
@@ -23,10 +23,6 @@ type Postgres struct {
 	Urlstr           string
 }
 
-const (
-	defaultPort = "5432"
-)
-
 func (db *Postgres) TestConnection(urlstr string) error {
 	return db.Connect(urlstr)
 }
@@ -759,33 +755,43 @@ func (db *Postgres) GetProvider() string {
 	return db.Provider
 }
 
+func dsnValue(dsn, key string) string {
+	prefix := key + "="
+	for _, part := range strings.Split(dsn, " ") {
+		if after, ok := strings.CutPrefix(part, prefix); ok {
+			return after
+		}
+	}
+	return ""
+}
+
+func buildReconnectURL(urlstr, newDB string) (string, error) {
+	parsed, err := dburl.Parse(urlstr)
+	if err != nil {
+		return "", err
+	}
+	if parsed.Transport == "unix" {
+		host := dsnValue(parsed.DSN, "host")
+		port := dsnValue(parsed.DSN, "port")
+		if port != "" {
+			parsed.Path = host + ":" + port + "/" + newDB
+		} else {
+			parsed.Path = host + "/" + newDB
+		}
+	} else {
+		parsed.Path = "/" + newDB
+	}
+	return parsed.String(), nil
+}
+
 // connectToDatabase opens a new connection to the given database without
 // mutating the receiver. The caller must close the returned connection.
 func (db *Postgres) connectToDatabase(database string) (*sql.DB, error) {
-	parsedConn, err := dburl.Parse(db.Urlstr)
+	urlstr, err := buildReconnectURL(db.Urlstr, database)
 	if err != nil {
 		return nil, err
 	}
-
-	user := parsedConn.User.Username()
-	password, hasPassword := parsedConn.User.Password()
-	host := parsedConn.Hostname()
-	port := parsedConn.Port()
-	if port == "" {
-		port = defaultPort
-	}
-
-	dsn := fmt.Sprintf("host=%s port=%s user=%s dbname=%s sslmode=disable", host, port, user, database)
-	if hasPassword {
-		dsn += fmt.Sprintf(" password=%s", password)
-	}
-
-	conn, err := sql.Open("postgres", dsn)
-	if err != nil {
-		return nil, err
-	}
-
-	return conn, nil
+	return dburl.Open(urlstr)
 }
 
 // connectionFor returns a connection to the given database. If it matches

--- a/drivers/postgres_test.go
+++ b/drivers/postgres_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	_ "github.com/lib/pq"
+	"github.com/xo/dburl"
 
 	"github.com/jorgerojas26/lazysql/models"
 )
@@ -611,5 +612,125 @@ func TestPostgres_formatTableName(t *testing.T) {
 
 	if tableName != expected {
 		t.Fatalf("formatTableName failed: got %s, expected %s", tableName, expected)
+	}
+}
+
+func TestDSNValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		dsn      string
+		key      string
+		expected string
+	}{
+		{"extracts host", "host=/var/run/postgresql port= dbname=", "host", "/var/run/postgresql"},
+		{"extracts dbname", "host=/tmp dbname=postgres", "dbname", "postgres"},
+		{"empty value", "host= port=", "host", ""},
+		{"missing key", "host=/tmp dbname=postgres", "user", ""},
+		{"empty dsn", "", "host", ""},
+		{"key is prefix of another key", "hostaddr=1.2.3.4 host=/tmp", "host", "/tmp"},
+		{"no space separators but key=value", "host=/tmp", "host", "/tmp"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := dsnValue(tt.dsn, tt.key)
+			if got != tt.expected {
+				t.Errorf("dsnValue(%q, %q) = %q, want %q", tt.dsn, tt.key, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBuildReconnectURL(t *testing.T) {
+	tests := []struct {
+		name          string
+		urlstr        string
+		newDB         string
+		wantTransport string
+		wantHost      string
+	}{
+		{
+			name:          "unix socket — no dbname in path",
+			urlstr:        "postgresql:///tmp",
+			newDB:         "mydb",
+			wantTransport: "unix",
+			wantHost:      "",
+		},
+		{
+			name:          "unix socket — dbname in path, replaced",
+			urlstr:        "postgresql:///tmp/postgres",
+			newDB:         "mydb",
+			wantTransport: "unix",
+			wantHost:      "",
+		},
+		{
+			name:          "unix socket with custom port — port preserved",
+			urlstr:        "postgresql:///tmp:6666/postgres",
+			newDB:         "mydb",
+			wantTransport: "unix",
+			wantHost:      "",
+		},
+		{
+			name:          "tcp — database replaced in path, host preserved",
+			urlstr:        "postgresql://localhost/postgres",
+			newDB:         "mydb",
+			wantTransport: "tcp",
+			wantHost:      "localhost",
+		},
+		{
+			name:          "tcp with user and sslmode — user + query preserved",
+			urlstr:        "postgresql://user@localhost/postgres?sslmode=disable",
+			newDB:         "other",
+			wantTransport: "tcp",
+			wantHost:      "localhost",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original, err := dburl.Parse(tt.urlstr)
+			if err != nil {
+				t.Fatalf("dburl.Parse(%q): %v", tt.urlstr, err)
+			}
+			originalHost := dsnValue(original.DSN, "host")
+			originalPort := dsnValue(original.DSN, "port")
+
+			got, err := buildReconnectURL(tt.urlstr, tt.newDB)
+			if err != nil {
+				t.Fatalf("buildReconnectURL(%q, %q): %v", tt.urlstr, tt.newDB, err)
+			}
+
+			reparsed, err := dburl.Parse(got)
+			if err != nil {
+				t.Fatalf("re-parse of %q failed: %v", got, err)
+			}
+			newHost := dsnValue(reparsed.DSN, "host")
+			newPort := dsnValue(reparsed.DSN, "port")
+			newDBName := dsnValue(reparsed.DSN, "dbname")
+
+			if reparsed.Transport != tt.wantTransport {
+				t.Errorf("Transport = %q, want %q", reparsed.Transport, tt.wantTransport)
+			}
+			if reparsed.Hostname() != tt.wantHost {
+				t.Errorf("Hostname = %q, want %q", reparsed.Hostname(), tt.wantHost)
+			}
+			if newHost != originalHost {
+				t.Errorf("host must be preserved: original=%q rebuilt=%q", originalHost, newHost)
+			}
+			if newPort != originalPort {
+				t.Errorf("port must be preserved: original=%q rebuilt=%q", originalPort, newPort)
+			}
+			if newDBName != tt.newDB {
+				t.Errorf("dbname = %q, want %q (rebuilt URL: %s)", newDBName, tt.newDB, got)
+			}
+			if tt.urlstr == "postgresql://user@localhost/postgres?sslmode=disable" {
+				if u := reparsed.User; u != nil {
+					if u.Username() != "user" {
+						t.Errorf("Username = %q, want %q", u.Username(), "user")
+					}
+				}
+				if reparsed.Query().Get("sslmode") != "disable" {
+					t.Errorf("sslmode = %q, want %q", reparsed.Query().Get("sslmode"), "disable")
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

  - Reworked Postgres database switching/reconnect URL construction to use `dburl` parsing
instead of manually rebuilding a lib/pq DSN.
  - Preserved original connection details when switching databases, including unix socket
host, custom socket port, user info, and query parameters.
  - Added focused tests for reconnect URL rebuilding and DSN value extraction.

  ## Why

  The previous reconnect logic manually created a DSN with hardcoded defaults, which could
drop connection options and did not handle unix socket URLs correctly.

  ## Testing

  - `go test ./...`
  
  Closes #301