### PR TITLE
feat: Postgres programming support — functions, procedures, views per-schema

### DIFF
--- a/components/tree.go
+++ b/components/tree.go
@@ -74,7 +74,12 @@ func (tree *Tree) GetTreeNodeData(node *tview.TreeNode) *TreeNodeData {
 	case len(split) == 3 && useSchemas && !supportsProgramming:
 		nodeType = NodeTypeTable
 		schema = split[len(split)-2]
+	case len(split) == 3 && useSchemas && supportsProgramming:
+		// Section header: [database, schema, section]
+		schema = split[1]
+		nodeType = NodeTypeSection
 	case len(split) == 3 && !useSchemas && supportsProgramming:
+		// Flat (non-schema) items: [database, section, name]
 		switch parentType := split[len(split)-2]; parentType {
 		case "tables":
 			nodeType = NodeTypeTable
@@ -88,7 +93,9 @@ func (tree *Tree) GetTreeNodeData(node *tview.TreeNode) *TreeNodeData {
 			nodeType = NodeTypeSection
 		}
 	case len(split) == 4 && useSchemas && supportsProgramming:
-		switch parentType := split[len(split)-2]; parentType {
+		// Items under a schema: [database, schema, section, name]
+		schema = split[1]
+		switch split[2] {
 		case "tables":
 			nodeType = NodeTypeTable
 		case "procedures":
@@ -100,8 +107,6 @@ func (tree *Tree) GetTreeNodeData(node *tview.TreeNode) *TreeNodeData {
 		default:
 			nodeType = NodeTypeSection
 		}
-
-		schema = split[len(split)-2]
 	default:
 		nodeType = NodeTypeSection
 	}
@@ -404,6 +409,98 @@ func (tree *Tree) databasesToNodes(children map[string][]string, node *tview.Tre
 
 			tablesContainer.AddChild(childNode)
 		}
+	}
+}
+
+// buildSchemaTree builds the complete per-schema subtree for a database node.
+// Each schema gets a node with "tables", and optionally "functions", "procedures", "views" sections.
+// The functions/procedures/views maps are keyed by database name and contain schema-qualified names.
+func (tree *Tree) buildSchemaTree(database string, node *tview.TreeNode, tables, functions, procedures, views map[string][]string) {
+	supportsProgramming := tree.DBDriver.SupportsProgramming()
+	sortedKeys := slices.Sorted(maps.Keys(tables))
+
+	for _, schema := range sortedKeys {
+		// Filter schemas if Schemas is configured
+		if len(tree.Schemas) > 0 {
+			found := false
+			for _, s := range tree.Schemas {
+				if s == schema {
+					found = true
+					break
+				}
+			}
+			if !found {
+				continue
+			}
+		}
+
+		schemaNode := tview.NewTreeNode(schema)
+		schemaNode.SetExpanded(false)
+		schemaNode.SetReference(schema)
+		schemaNode.SetColor(app.Styles.PrimaryTextColor)
+		node.AddChild(schemaNode)
+
+		if supportsProgramming {
+			tablesNode := tview.NewTreeNode("tables")
+			tablesNode.SetExpanded(false)
+			tablesNode.SetReference(fmt.Sprintf("%s.tables", schema))
+			tablesNode.SetColor(app.Styles.PrimaryTextColor)
+			schemaNode.AddChild(tablesNode)
+
+			for _, child := range tables[schema] {
+				childNode := tview.NewTreeNode(child)
+				childNode.SetExpanded(true)
+				childNode.SetColor(app.Styles.PrimaryTextColor)
+				childNode.SetReference(fmt.Sprintf("%s.%s.tables.%s", database, schema, child))
+				tablesNode.AddChild(childNode)
+			}
+		} else {
+			for _, child := range tables[schema] {
+				childNode := tview.NewTreeNode(child)
+				childNode.SetExpanded(true)
+				childNode.SetColor(app.Styles.PrimaryTextColor)
+				childNode.SetReference(fmt.Sprintf("%s.%s.%s", database, schema, child))
+				schemaNode.AddChild(childNode)
+			}
+		}
+
+		if supportsProgramming {
+			tree.addSchemaProgrammingSection(schemaNode, database, schema, "functions", functions)
+			tree.addSchemaProgrammingSection(schemaNode, database, schema, "procedures", procedures)
+			tree.addSchemaProgrammingSection(schemaNode, database, schema, "views", views)
+		}
+	}
+}
+
+// addSchemaProgrammingSection adds a single programming section (e.g. "functions") under a schema node.
+// It filters items from the programmingMap that belong to the given schema (schema-qualified names).
+func (tree *Tree) addSchemaProgrammingSection(schemaNode *tview.TreeNode, database, schema, section string, programmingMap map[string][]string) {
+	prefix := schema + "."
+	var items []string
+	for _, qualified := range programmingMap[database] {
+		if strings.HasPrefix(qualified, prefix) {
+			items = append(items, strings.TrimPrefix(qualified, prefix))
+		}
+	}
+
+	if len(items) == 0 {
+		return
+	}
+
+	sort.Strings(items)
+
+	sectionNode := tview.NewTreeNode(section)
+	sectionNode.SetExpanded(false)
+	sectionNode.SetReference(fmt.Sprintf("%s.%s.%s", database, schema, section))
+	sectionNode.SetColor(app.Styles.PrimaryTextColor)
+	schemaNode.AddChild(sectionNode)
+
+	for _, item := range items {
+		itemNode := tview.NewTreeNode(item)
+		itemNode.SetExpanded(false)
+		itemNode.SetColor(app.Styles.PrimaryTextColor)
+		itemNode.SetReference(fmt.Sprintf("%s.%s.%s.%s", database, schema, section, item))
+		sectionNode.AddChild(itemNode)
 	}
 }
 
@@ -899,28 +996,37 @@ func (tree *Tree) InitializeNodes(dbName string) {
 				return
 			}
 
-			tree.databasesToNodes(tables, node, true)
+			supportsProgramming := tree.DBDriver.SupportsProgramming()
+			useSchemas := tree.DBDriver.UseSchemas()
 
-			if tree.DBDriver.SupportsProgramming() {
-				functions, err := tree.DBDriver.GetFunctions(database)
+			var functions, procedures, views map[string][]string
+			if supportsProgramming {
+				functions, err = tree.DBDriver.GetFunctions(database)
 				if err != nil {
 					logger.Error(err.Error(), nil)
 					return
 				}
 
-				procedures, err := tree.DBDriver.GetProcedures(database)
+				procedures, err = tree.DBDriver.GetProcedures(database)
 				if err != nil {
 					logger.Error(err.Error(), nil)
 					return
 				}
 
-				views, err := tree.DBDriver.GetViews(database)
+				views, err = tree.DBDriver.GetViews(database)
 				if err != nil {
 					logger.Error(err.Error(), nil)
 					return
 				}
+			}
 
-				tree.addProgrammingNodes(functions, procedures, views, node)
+			if useSchemas {
+				tree.buildSchemaTree(database, node, tables, functions, procedures, views)
+			} else {
+				tree.databasesToNodes(tables, node, true)
+				if supportsProgramming {
+					tree.addProgrammingNodes(functions, procedures, views, node)
+				}
 			}
 
 			App.Draw()

--- a/components/tree.go
+++ b/components/tree.go
@@ -417,7 +417,31 @@ func (tree *Tree) databasesToNodes(children map[string][]string, node *tview.Tre
 // The functions/procedures/views maps are keyed by database name and contain schema-qualified names.
 func (tree *Tree) buildSchemaTree(database string, node *tview.TreeNode, tables, functions, procedures, views map[string][]string) {
 	supportsProgramming := tree.DBDriver.SupportsProgramming()
-	sortedKeys := slices.Sorted(maps.Keys(tables))
+
+	// Collect unique schema names from tables and, when supported, from
+	// functions/procedures/views (whose values are "schema.name" strings).
+	schemaSet := make(map[string]struct{})
+	for k := range tables {
+		schemaSet[k] = struct{}{}
+	}
+	if supportsProgramming {
+		for _, items := range functions[database] {
+			if idx := strings.IndexByte(items, '.'); idx > 0 {
+				schemaSet[items[:idx]] = struct{}{}
+			}
+		}
+		for _, items := range procedures[database] {
+			if idx := strings.IndexByte(items, '.'); idx > 0 {
+				schemaSet[items[:idx]] = struct{}{}
+			}
+		}
+		for _, items := range views[database] {
+			if idx := strings.IndexByte(items, '.'); idx > 0 {
+				schemaSet[items[:idx]] = struct{}{}
+			}
+		}
+	}
+	sortedKeys := slices.Sorted(maps.Keys(schemaSet))
 
 	for _, schema := range sortedKeys {
 		// Filter schemas if Schemas is configured

--- a/components/tree_test.go
+++ b/components/tree_test.go
@@ -1,9 +1,13 @@
 package components
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/rivo/tview"
+
+	"github.com/jorgerojas26/lazysql/drivers"
+	"github.com/jorgerojas26/lazysql/models"
 )
 
 // ── stripColorTags ──────────────────────────────────────────────────────────
@@ -288,5 +292,328 @@ func TestExpandAncestors_AlreadyExpanded(t *testing.T) {
 
 	if !db.IsExpanded() {
 		t.Error("db should remain expanded")
+	}
+}
+
+// ── schemaProgrammingMock ───────────────────────────────────────────────────────
+// Implements drivers.Driver with SupportsProgramming()=true and UseSchemas()=true.
+// Used to test buildSchemaTree, addSchemaProgrammingSection, and the new
+// GetTreeNodeData paths.
+
+var _ drivers.Driver = (*schemaProgrammingMock)(nil)
+
+type schemaProgrammingMock struct{}
+
+func (m *schemaProgrammingMock) Connect(string) error                               { return nil }
+func (m *schemaProgrammingMock) TestConnection(string) error                        { return nil }
+func (m *schemaProgrammingMock) GetDatabases() ([]string, error)                    { return nil, nil }
+func (m *schemaProgrammingMock) GetTables(string) (map[string][]string, error)      { return nil, nil }
+func (m *schemaProgrammingMock) GetTableColumns(string, string) ([][]string, error) { return nil, nil }
+func (m *schemaProgrammingMock) GetConstraints(string, string) ([][]string, error)  { return nil, nil }
+func (m *schemaProgrammingMock) GetForeignKeys(string, string) ([][]string, error)  { return nil, nil }
+func (m *schemaProgrammingMock) GetIndexes(string, string) ([][]string, error)      { return nil, nil }
+func (m *schemaProgrammingMock) GetRecords(string, string, string, string, int, int) ([][]string, int, string, error) {
+	return nil, 0, "", nil
+}
+func (m *schemaProgrammingMock) UpdateRecord(string, string, string, string, string, string) error {
+	return nil
+}
+func (m *schemaProgrammingMock) DeleteRecord(string, string, string, string) error { return nil }
+func (m *schemaProgrammingMock) ExecuteDMLStatement(string) (string, error)        { return "", nil }
+func (m *schemaProgrammingMock) ExecuteQuery(string) ([][]string, int, error)      { return nil, 0, nil }
+func (m *schemaProgrammingMock) ExecutePendingChanges([]models.DBDMLChange) error  { return nil }
+func (m *schemaProgrammingMock) GetProvider() string                               { return "mock" }
+func (m *schemaProgrammingMock) GetPrimaryKeyColumnNames(string, string) ([]string, error) {
+	return nil, nil
+}
+func (m *schemaProgrammingMock) SupportsProgramming() bool                            { return true }
+func (m *schemaProgrammingMock) UseSchemas() bool                                     { return true }
+func (m *schemaProgrammingMock) GetFunctions(string) (map[string][]string, error)     { return nil, nil }
+func (m *schemaProgrammingMock) GetProcedures(string) (map[string][]string, error)    { return nil, nil }
+func (m *schemaProgrammingMock) GetViews(string) (map[string][]string, error)         { return nil, nil }
+func (m *schemaProgrammingMock) GetFunctionDefinition(string, string) (string, error) { return "", nil }
+func (m *schemaProgrammingMock) GetProcedureDefinition(string, string) (string, error) {
+	return "", nil
+}
+func (m *schemaProgrammingMock) GetViewDefinition(string, string) (string, error) { return "", nil }
+
+func (m *schemaProgrammingMock) FormatArg(arg any, _ models.CellValueType) any {
+	return arg
+}
+func (m *schemaProgrammingMock) FormatArgForQueryString(arg any) string {
+	return fmt.Sprintf("%v", arg)
+}
+func (m *schemaProgrammingMock) FormatReference(reference string) string {
+	return fmt.Sprintf("\"%s\"", reference)
+}
+func (m *schemaProgrammingMock) FormatPlaceholder(index int) string {
+	return fmt.Sprintf("$%d", index)
+}
+func (m *schemaProgrammingMock) DMLChangeToQueryString(models.DBDMLChange) (string, error) {
+	return "", nil
+}
+func (m *schemaProgrammingMock) SetProvider(string) {}
+
+// ── buildSchemaTree tests ───────────────────────────────────────────────────────
+
+func TestBuildSchemaTree_BasicStructure(t *testing.T) {
+	tree := &Tree{DBDriver: &schemaProgrammingMock{}}
+
+	dbNode := tview.NewTreeNode("mydb")
+	dbNode.SetReference("mydb")
+
+	tables := map[string][]string{"public": {"users", "posts"}}
+	functions := map[string][]string{"mydb": {"public.add_user"}}
+	procedures := map[string][]string{"mydb": {"public.cleanup"}}
+	views := map[string][]string{"mydb": {"public.user_view"}}
+
+	tree.buildSchemaTree("mydb", dbNode, tables, functions, procedures, views)
+
+	// ── db node has 1 child (schema "public") ──
+	children := dbNode.GetChildren()
+	if len(children) != 1 {
+		t.Fatalf("expected 1 child (schema) under db node, got %d", len(children))
+	}
+
+	schemaNode := children[0]
+	if schemaNode.GetText() != "public" {
+		t.Errorf("expected schema node text 'public', got '%s'", schemaNode.GetText())
+	}
+
+	// ── schema node has 4 children: tables, functions, procedures, views ──
+	schemaChildren := schemaNode.GetChildren()
+	if len(schemaChildren) != 4 {
+		t.Fatalf("expected 4 children under schema node, got %d", len(schemaChildren))
+	}
+
+	sectionNames := []string{"tables", "functions", "procedures", "views"}
+	for i, name := range sectionNames {
+		if schemaChildren[i].GetText() != name {
+			t.Errorf("expected section %d text '%s', got '%s'", i, name, schemaChildren[i].GetText())
+		}
+	}
+
+	// ── "tables" section has 2 children: "users", "posts" ──
+	tablesSection := schemaChildren[0]
+	tableChildren := tablesSection.GetChildren()
+	if len(tableChildren) != 2 {
+		t.Fatalf("expected 2 table children, got %d", len(tableChildren))
+	}
+	if tableChildren[0].GetText() != "users" {
+		t.Errorf("expected first table 'users', got '%s'", tableChildren[0].GetText())
+	}
+	if tableChildren[1].GetText() != "posts" {
+		t.Errorf("expected second table 'posts', got '%s'", tableChildren[1].GetText())
+	}
+	if tableChildren[0].GetReference().(string) != "mydb.public.tables.users" {
+		t.Errorf("expected table reference 'mydb.public.tables.users', got '%s'", tableChildren[0].GetReference().(string))
+	}
+	if tableChildren[1].GetReference().(string) != "mydb.public.tables.posts" {
+		t.Errorf("expected table reference 'mydb.public.tables.posts', got '%s'", tableChildren[1].GetReference().(string))
+	}
+
+	// ── "functions" section has 1 child: "add_user" (NOT "public.add_user") ──
+	functionsSection := schemaChildren[1]
+	funcChildren := functionsSection.GetChildren()
+	if len(funcChildren) != 1 {
+		t.Fatalf("expected 1 function child, got %d", len(funcChildren))
+	}
+	if funcChildren[0].GetText() != "add_user" {
+		t.Errorf("expected function 'add_user', got '%s'", funcChildren[0].GetText())
+	}
+	if funcChildren[0].GetReference().(string) != "mydb.public.functions.add_user" {
+		t.Errorf("expected reference 'mydb.public.functions.add_user', got '%s'", funcChildren[0].GetReference().(string))
+	}
+
+	// ── "procedures" section has 1 child: "cleanup" ──
+	proceduresSection := schemaChildren[2]
+	procChildren := proceduresSection.GetChildren()
+	if len(procChildren) != 1 {
+		t.Fatalf("expected 1 procedure child, got %d", len(procChildren))
+	}
+	if procChildren[0].GetText() != "cleanup" {
+		t.Errorf("expected procedure 'cleanup', got '%s'", procChildren[0].GetText())
+	}
+	if procChildren[0].GetReference().(string) != "mydb.public.procedures.cleanup" {
+		t.Errorf("expected reference 'mydb.public.procedures.cleanup', got '%s'", procChildren[0].GetReference().(string))
+	}
+
+	// ── "views" section has 1 child: "user_view" ──
+	viewsSection := schemaChildren[3]
+	viewChildren := viewsSection.GetChildren()
+	if len(viewChildren) != 1 {
+		t.Fatalf("expected 1 view child, got %d", len(viewChildren))
+	}
+	if viewChildren[0].GetText() != "user_view" {
+		t.Errorf("expected view 'user_view', got '%s'", viewChildren[0].GetText())
+	}
+	if viewChildren[0].GetReference().(string) != "mydb.public.views.user_view" {
+		t.Errorf("expected reference 'mydb.public.views.user_view', got '%s'", viewChildren[0].GetReference().(string))
+	}
+}
+
+// TestBuildSchemaTree_SchemaWithOnlyFunctions validates that schemas containing
+// only programming objects (functions/procedures/views) but no tables still
+// appear in the tree. On this branch, buildSchemaTree collects schema names
+// from all maps (tables + functions/procedures/views), so "api" appears even
+// though it has no tables.
+func TestBuildSchemaTree_SchemaWithOnlyFunctions(t *testing.T) {
+	tree := &Tree{DBDriver: &schemaProgrammingMock{}}
+
+	dbNode := tview.NewTreeNode("mydb")
+	dbNode.SetReference("mydb")
+
+	tables := map[string][]string{"public": {"users"}}
+	functions := map[string][]string{"mydb": {"api.get_data"}}
+	procedures := map[string][]string{}
+	views := map[string][]string{}
+
+	tree.buildSchemaTree("mydb", dbNode, tables, functions, procedures, views)
+
+	children := dbNode.GetChildren()
+
+	// Expect both "api" (from functions) and "public" (from tables)
+	if len(children) != 2 {
+		t.Fatalf("expected 2 schema children (api, public), got %d", len(children))
+	}
+
+	// Sorted keys: ["api", "public"] — "api" comes first alphabetically
+	apiNode := children[0]
+	if apiNode.GetText() != "api" {
+		t.Errorf("expected first schema 'api', got '%s'", apiNode.GetText())
+	}
+
+	// "api" has a "tables" section (created unconditionally when supportsProgramming)
+	// plus a "functions" section with "get_data"
+	apiChildren := apiNode.GetChildren()
+	if len(apiChildren) != 2 {
+		t.Fatalf("expected 2 children under 'api' (tables + functions), got %d", len(apiChildren))
+	}
+	if apiChildren[0].GetText() != "tables" {
+		t.Errorf("expected 'tables' section under 'api', got '%s'", apiChildren[0].GetText())
+	}
+	if apiChildren[1].GetText() != "functions" {
+		t.Errorf("expected 'functions' section under 'api', got '%s'", apiChildren[1].GetText())
+	}
+
+	// "api" tables section should have no children (no tables for "api")
+	if len(apiChildren[0].GetChildren()) != 0 {
+		t.Errorf("expected no tables under 'api', got %d", len(apiChildren[0].GetChildren()))
+	}
+
+	// Verify the function item
+	funcSection := apiChildren[1]
+	funcItems := funcSection.GetChildren()
+	if len(funcItems) != 1 {
+		t.Fatalf("expected 1 function under api, got %d", len(funcItems))
+	}
+	if funcItems[0].GetText() != "get_data" {
+		t.Errorf("expected function 'get_data', got '%s'", funcItems[0].GetText())
+	}
+
+	// Second child: "public" has tables but no matching functions/procedures/views
+	publicNode := children[1]
+	if publicNode.GetText() != "public" {
+		t.Errorf("expected second schema 'public', got '%s'", publicNode.GetText())
+	}
+	publicChildren := publicNode.GetChildren()
+	if len(publicChildren) != 1 {
+		t.Fatalf("expected 1 child under 'public' (just tables), got %d", len(publicChildren))
+	}
+	if publicChildren[0].GetText() != "tables" {
+		t.Errorf("expected 'tables' section under 'public', got '%s'", publicChildren[0].GetText())
+	}
+	if len(publicChildren[0].GetChildren()) != 1 {
+		t.Fatalf("expected 1 table under 'public', got %d", len(publicChildren[0].GetChildren()))
+	}
+	if publicChildren[0].GetChildren()[0].GetText() != "users" {
+		t.Errorf("expected table 'users', got '%s'", publicChildren[0].GetChildren()[0].GetText())
+	}
+}
+
+// ── addSchemaProgrammingSection tests ───────────────────────────────────────────
+
+func TestAddSchemaProgrammingSection_EmptySection(t *testing.T) {
+	tree := &Tree{DBDriver: &schemaProgrammingMock{}}
+
+	schemaNode := tview.NewTreeNode("public")
+	schemaNode.SetReference("public")
+
+	// programmingMap with no items for the "public" schema
+	programmingMap := map[string][]string{"mydb": {"other_schema.some_func"}}
+
+	tree.addSchemaProgrammingSection(schemaNode, "mydb", "public", "functions", programmingMap)
+
+	// No child should have been added because no items matched the prefix "public."
+	if len(schemaNode.GetChildren()) != 0 {
+		t.Errorf("expected no children added for empty section, got %d", len(schemaNode.GetChildren()))
+	}
+}
+
+// ── GetTreeNodeData schema programming tests ────────────────────────────────────
+
+func TestGetTreeNodeDataSchemaProgramming_SectionHeader(t *testing.T) {
+	tree := &Tree{DBDriver: &schemaProgrammingMock{}}
+
+	node := tview.NewTreeNode("functions")
+	node.SetReference("mydb.public.functions")
+
+	data := tree.GetTreeNodeData(node)
+
+	if data.Type != NodeTypeSection {
+		t.Errorf("expected NodeTypeSection, got %v", data.Type)
+	}
+	if data.Database != "mydb" {
+		t.Errorf("expected Database 'mydb', got '%s'", data.Database)
+	}
+	if data.Schema != "public" {
+		t.Errorf("expected Schema 'public', got '%s'", data.Schema)
+	}
+	if data.Name != "functions" {
+		t.Errorf("expected Name 'functions', got '%s'", data.Name)
+	}
+}
+
+func TestGetTreeNodeDataSchemaProgramming_ItemNode(t *testing.T) {
+	tree := &Tree{DBDriver: &schemaProgrammingMock{}}
+
+	node := tview.NewTreeNode("add_user")
+	node.SetReference("mydb.public.functions.add_user")
+
+	data := tree.GetTreeNodeData(node)
+
+	if data.Type != NodeTypeFunction {
+		t.Errorf("expected NodeTypeFunction, got %v", data.Type)
+	}
+	if data.Database != "mydb" {
+		t.Errorf("expected Database 'mydb', got '%s'", data.Database)
+	}
+	if data.Schema != "public" {
+		t.Errorf("expected Schema 'public', got '%s'", data.Schema)
+	}
+	if data.Name != "add_user" {
+		t.Errorf("expected Name 'add_user', got '%s'", data.Name)
+	}
+}
+
+func TestGetTreeNodeDataSchemaProgramming_TableItem(t *testing.T) {
+	tree := &Tree{DBDriver: &schemaProgrammingMock{}}
+
+	node := tview.NewTreeNode("users")
+	node.SetReference("mydb.public.tables.users")
+
+	data := tree.GetTreeNodeData(node)
+
+	if data.Type != NodeTypeTable {
+		t.Errorf("expected NodeTypeTable, got %v", data.Type)
+	}
+	if data.Database != "mydb" {
+		t.Errorf("expected Database 'mydb', got '%s'", data.Database)
+	}
+	if data.Schema != "public" {
+		t.Errorf("expected Schema 'public', got '%s'", data.Schema)
+	}
+	if data.Name != "users" {
+		t.Errorf("expected Name 'users', got '%s'", data.Name)
 	}
 }

--- a/drivers/postgres.go
+++ b/drivers/postgres.go
@@ -927,34 +927,239 @@ func (db *Postgres) DMLChangeToQueryString(change models.DBDMLChange) (string, e
 	return queryStr, nil
 }
 
-func (db *Postgres) GetFunctions(_ string) (map[string][]string, error) {
-	return nil, errors.New("not implemented")
+func (db *Postgres) GetFunctions(database string) (map[string][]string, error) {
+	if database == "" {
+		return nil, errors.New("database name is required")
+	}
+
+	conn, needsClose, err := db.connectionFor(database)
+	if err != nil {
+		return nil, err
+	}
+	if needsClose {
+		defer conn.Close()
+	}
+
+	rows, err := conn.Query(`
+		SELECT n.nspname || '.' || p.proname
+		FROM pg_catalog.pg_proc p
+		JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+		WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+		AND p.prokind = 'f'
+		ORDER BY n.nspname, p.proname
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	functions := make(map[string][]string)
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		functions[database] = append(functions[database], name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return functions, nil
 }
 
-func (db *Postgres) GetProcedures(_ string) (map[string][]string, error) {
-	return nil, errors.New("not implemented")
+func (db *Postgres) GetProcedures(database string) (map[string][]string, error) {
+	if database == "" {
+		return nil, errors.New("database name is required")
+	}
+
+	conn, needsClose, err := db.connectionFor(database)
+	if err != nil {
+		return nil, err
+	}
+	if needsClose {
+		defer conn.Close()
+	}
+
+	rows, err := conn.Query(`
+		SELECT n.nspname || '.' || p.proname
+		FROM pg_catalog.pg_proc p
+		JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+		WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+		AND p.prokind = 'p'
+		ORDER BY n.nspname, p.proname
+	`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	procedures := make(map[string][]string)
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		procedures[database] = append(procedures[database], name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return procedures, nil
 }
 
-func (db *Postgres) GetViews(_ string) (map[string][]string, error) {
-	return nil, errors.New("not implemented")
+func (db *Postgres) GetViews(database string) (map[string][]string, error) {
+	if database == "" {
+		return nil, errors.New("database name is required")
+	}
+
+	conn, needsClose, err := db.connectionFor(database)
+	if err != nil {
+		return nil, err
+	}
+	if needsClose {
+		defer conn.Close()
+	}
+
+	rows, err := conn.Query(`
+		SELECT table_schema || '.' || table_name
+		FROM information_schema.views
+		WHERE table_catalog = $1
+		AND table_schema NOT IN ('pg_catalog', 'information_schema')
+		ORDER BY table_schema, table_name
+	`, database)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	views := make(map[string][]string)
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, err
+		}
+		views[database] = append(views[database], name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return views, nil
 }
 
 func (db *Postgres) SupportsProgramming() bool {
-	return false
+	return true
 }
 
 func (db *Postgres) UseSchemas() bool {
 	return true
 }
 
-func (db *Postgres) GetFunctionDefinition(_ string, _ string) (string, error) {
-	return "", errors.New("not implemented")
+func (db *Postgres) GetFunctionDefinition(database, name string) (string, error) {
+	if database == "" {
+		return "", errors.New("database name is required")
+	}
+	if name == "" {
+		return "", errors.New("function name is required")
+	}
+
+	parts := strings.SplitN(name, ".", 2)
+	if len(parts) != 2 {
+		return "", errors.New("function name must be in format schema.name")
+	}
+
+	conn, needsClose, err := db.connectionFor(database)
+	if err != nil {
+		return "", err
+	}
+	if needsClose {
+		defer conn.Close()
+	}
+
+	var result string
+	row := conn.QueryRow(`
+		SELECT pg_get_functiondef(p.oid)
+		FROM pg_catalog.pg_proc p
+		JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+		WHERE n.nspname = $1 AND p.proname = $2
+		LIMIT 1
+	`, parts[0], parts[1])
+	if err := row.Scan(&result); err != nil {
+		return "", err
+	}
+
+	return result, nil
 }
 
-func (db *Postgres) GetProcedureDefinition(_ string, _ string) (string, error) {
-	return "", errors.New("not implemented")
+func (db *Postgres) GetProcedureDefinition(database, name string) (string, error) {
+	if database == "" {
+		return "", errors.New("database name is required")
+	}
+	if name == "" {
+		return "", errors.New("procedure name is required")
+	}
+
+	parts := strings.SplitN(name, ".", 2)
+	if len(parts) != 2 {
+		return "", errors.New("procedure name must be in format schema.name")
+	}
+
+	conn, needsClose, err := db.connectionFor(database)
+	if err != nil {
+		return "", err
+	}
+	if needsClose {
+		defer conn.Close()
+	}
+
+	var result string
+	row := conn.QueryRow(`
+		SELECT pg_get_functiondef(p.oid)
+		FROM pg_catalog.pg_proc p
+		JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+		WHERE n.nspname = $1 AND p.proname = $2
+		AND p.prokind = 'p'
+		LIMIT 1
+	`, parts[0], parts[1])
+	if err := row.Scan(&result); err != nil {
+		return "", err
+	}
+
+	return result, nil
 }
 
-func (db *Postgres) GetViewDefinition(_ string, _ string) (string, error) {
-	return "", errors.New("not implemented")
+func (db *Postgres) GetViewDefinition(database, name string) (string, error) {
+	if database == "" {
+		return "", errors.New("database name is required")
+	}
+	if name == "" {
+		return "", errors.New("view name is required")
+	}
+
+	parts := strings.SplitN(name, ".", 2)
+	if len(parts) != 2 {
+		return "", errors.New("view name must be in format schema.name")
+	}
+
+	conn, needsClose, err := db.connectionFor(database)
+	if err != nil {
+		return "", err
+	}
+	if needsClose {
+		defer conn.Close()
+	}
+
+	var result string
+	row := conn.QueryRow(`
+		SELECT definition
+		FROM pg_catalog.pg_views
+		WHERE schemaname = $1 AND viewname = $2
+	`, parts[0], parts[1])
+	if err := row.Scan(&result); err != nil {
+		return "", err
+	}
+
+	return result, nil
 }


### PR DESCRIPTION
## Summary

Implements programming features for the Postgres driver: **functions**, **procedures**, and **views** now appear in the tree, and clicking them opens their definition in the editor (editable — modify and press Execute to apply DDL).

## Changes

### Postgres driver (drivers/postgres.go)
- **GetFunctions** — queries pg_proc where prokind is f, returns schema-qualified names
- **GetProcedures** — queries pg_proc where prokind is p (PG11+ stored procedures)
- **GetViews** — queries information_schema.views
- **GetFunctionDefinition / GetProcedureDefinition** — uses pg_get_functiondef() with schema/name lookup
- **GetViewDefinition** — queries pg_views
- **SupportsProgramming** — now returns true

### Tree component (components/tree.go)
- **Per-schema layout** — functions/procedures/views listed under each schema alongside tables, instead of flat at database level
- **Fixed item clicking** — references use consistent {database}.{schema}.{section}.{name} format so GetTreeNodeData correctly identifies nodes
- **buildSchemaTree** (new) — builds per-schema subtree with tables + programming sections
- **addSchemaProgrammingSection** (new) — filters schema-qualified names, adds items under correct section
- **GetTreeNodeData** — simplified

## Testing
- go build ./... — clean
- go test ./... — all tests pass
- Verified in app: tree shows functions/procedures/views per-schema, clicking opens definitions in editor, editing + Execute applies DDL