### PR TITLE
fix: auto-expand database node when DB is specified in connection URL

### DIFF
--- a/components/tree.go
+++ b/components/tree.go
@@ -887,7 +887,7 @@ func (tree *Tree) InitializeNodes(dbName string) {
 
 	for _, database := range databases {
 		childNode := tview.NewTreeNode(database)
-		childNode.SetExpanded(false)
+		childNode.SetExpanded(dbName != "")
 		childNode.SetReference(database)
 		childNode.SetColor(app.Styles.PrimaryTextColor)
 		rootNode.AddChild(childNode)


### PR DESCRIPTION
- Fixes #82 

## Problem

https://github.com/user-attachments/assets/2c902636-4ad7-4692-8ea5-f25c2eca8d80

When connecting with a URL that includes a specific database (e.g. `mysql://root:password@localhost/mydb`), the database node in the tree was always initialized as collapsed. The tables were being fetched correctly in the background, but the user had to manually press Enter to expand the node and see them.

## Fix

https://github.com/user-attachments/assets/5656b3e5-a56b-4e63-9e1c-481f751f1fd4

One-line change in `tree.go` — the database node now auto-expands when a specific database name is provided in the connection URL. When no database is specified (showing all databases), nodes remain collapsed as before, so existing behavior is unchanged.

## Testing
Tested with `mysql://root:root@localhost/<dbname>` — tables are now visible immediately on connect without any manual interaction.