### PR TITLE
feat: session persistence / remember last selected table

### DIFF
--- a/components/home.go
+++ b/components/home.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jorgerojas26/lazysql/drivers"
 	"github.com/jorgerojas26/lazysql/helpers/logger"
 	"github.com/jorgerojas26/lazysql/internal/history"
+	"github.com/jorgerojas26/lazysql/internal/session"
 	"github.com/jorgerojas26/lazysql/models"
 )
 
@@ -120,6 +121,17 @@ func NewHomePage(connection models.Connection, dbdriver drivers.Driver) *Home {
 			home.focusRightWrapper()
 		}
 	})
+
+	if app.App.Config().RememberLastTable {
+		savedSession, err := session.Load(connectionIdentifier)
+		if err != nil {
+			logger.Error("Failed to load session", map[string]any{"error": err})
+		} else if savedSession.Database != "" && savedSession.Table != "" {
+			tree.OnReady = func() {
+				home.showTable(savedSession.Database, savedSession.Table)
+			}
+		}
+	}
 
 	mainPages.AddPage(connection.URL, home, true, false)
 	return home
@@ -453,6 +465,16 @@ func (home *Home) homeInputCapture(event *tcell.EventKey) *tcell.EventKey {
 		}
 	case commands.Quit:
 		if tab == nil || (!table.GetIsEditing() && !table.GetIsFiltering()) {
+			if app.App.Config().RememberLastTable {
+				var db, tbl string
+				if tab != nil {
+					db = table.GetDatabaseName()
+					tbl = table.GetTableName()
+				}
+				if err := session.Save(home.ConnectionIdentifier, db, tbl); err != nil {
+					logger.Error("Failed to save session", map[string]any{"error": err})
+				}
+			}
 			app.App.Stop()
 		}
 	case commands.Save:

--- a/components/tree.go
+++ b/components/tree.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/lithammer/fuzzysearch/fuzzy"
@@ -35,6 +36,8 @@ type Tree struct {
 	FoundNodeCountInput *tview.InputField
 	subscribers         []chan models.StateChange
 	Schemas             []string
+	OnReady             func()
+	onReadyMu           sync.Mutex
 }
 
 type TreeNodeType int
@@ -924,6 +927,14 @@ func (tree *Tree) InitializeNodes(dbName string) {
 			}
 
 			App.Draw()
+
+			tree.onReadyMu.Lock()
+			onReady := tree.OnReady
+			tree.OnReady = nil
+			tree.onReadyMu.Unlock()
+			if onReady != nil {
+				onReady()
+			}
 		}(database, childNode)
 	}
 }

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -1,0 +1,94 @@
+package session
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/jorgerojas26/lazysql/app"
+)
+
+const (
+	sessionDirName       = "session"
+	lazysqlConfigDirName = "lazysql"
+	sessionFileExtension = ".json"
+)
+
+type Session struct {
+	Database string `json:"database"`
+	Table    string `json:"table"`
+}
+
+func getSessionFilePath(connectionIdentifier string) (string, error) {
+	configDir, err := app.GetConfigPath()
+	if err != nil {
+		return "", fmt.Errorf("failed to get config directory: %w", err)
+	}
+
+	sessionDir := filepath.Join(configDir, lazysqlConfigDirName, sessionDirName)
+
+	if err := os.MkdirAll(sessionDir, 0o700); err != nil {
+		return "", fmt.Errorf("failed to create session directory: %w", err)
+	}
+
+	return filepath.Join(sessionDir, sanitizeFilename(connectionIdentifier)+sessionFileExtension), nil
+}
+
+func sanitizeFilename(name string) string {
+	if name == "" {
+		return "default_connection"
+	}
+	reg := regexp.MustCompile(`[<>:"/\\|?*\s]+`)
+	sanitized := reg.ReplaceAllString(name, "_")
+	reg = regexp.MustCompile("[^a-zA-Z0-9_.-]+")
+	sanitized = reg.ReplaceAllString(sanitized, "_")
+	const maxLength = 100
+	if len(sanitized) > maxLength {
+		sanitized = sanitized[:maxLength]
+	}
+	return strings.ToLower(sanitized)
+}
+
+func Save(connectionIdentifier, database, table string) error {
+	if database == "" || table == "" {
+		return nil
+	}
+
+	filePath, err := getSessionFilePath(connectionIdentifier)
+	if err != nil {
+		return err
+	}
+
+	data, err := json.MarshalIndent(Session{Database: database, Table: table}, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to marshal session: %w", err)
+	}
+
+	return os.WriteFile(filePath, data, 0o600)
+}
+
+func Load(connectionIdentifier string) (Session, error) {
+	filePath, err := getSessionFilePath(connectionIdentifier)
+	if err != nil {
+		return Session{}, err
+	}
+
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		return Session{}, nil
+	}
+
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return Session{}, fmt.Errorf("failed to read session file: %w", err)
+	}
+
+	var s Session
+	if err := json.Unmarshal(data, &s); err != nil {
+		return Session{}, fmt.Errorf("failed to unmarshal session: %w", err)
+	}
+
+	return s, nil
+}

--- a/models/models.go
+++ b/models/models.go
@@ -14,6 +14,7 @@ type AppConfig struct {
 	TreeWidth                    int
 	JSONViewerWordWrap           bool
 	EnterOpensJSONViewer         bool
+	RememberLastTable            bool
 }
 
 type Connection struct {


### PR DESCRIPTION
## Summary

Implements session persistence so lazysql remembers the last selected database and table per connection, and automatically restores it on the next launch.

- Closes #292

https://github.com/user-attachments/assets/15cf16f7-9d8c-4155-987b-aaa15632b515

## Changes

- **`internal/session/`** — new package with `Save`/`Load` functions
  that persist the last-viewed `{database, table}` as a JSON file at
  `~/.config/lazysql/session/<connection>.json`
- **`models/models.go`** — added `RememberLastTable bool` to `AppConfig`
- **`components/tree.go`** — added `OnReady` callback that fires once
  after tree nodes finish loading; protected with a mutex to prevent
  races on multi-database connections
- **`components/home.go`** — on startup, loads the saved session and
  uses `OnReady` to navigate to the last table; on quit, saves the
  current tab's database and table to the session file

## How to enable

Add the following to your `config.toml` under `[application]`:

```toml
[application]
RememberLastTable = true
```