### PR TITLE
fix: preserve connection fields when editing

### DIFF
--- a/components/connection_form.go
+++ b/components/connection_form.go
@@ -131,17 +131,16 @@ func (form *ConnectionForm) inputCapture(connectionPages *models.ConnectionPages
 
 				for i, database := range databases {
 					if i == row {
-						newDatabases[i] = parsedDatabaseData
-
-						// newDatabases[i].Name = connectionName
-						// newDatabases[i].Provider = database.Provider
-						// newDatabases[i].User = parsed.User.Username()
-						// newDatabases[i].Password, _ = parsed.User.Password()
-						// newDatabases[i].Host = parsed.Hostname()
-						// newDatabases[i].Port = parsed.Port()
-						// newDatabases[i].Query = parsed.Query().Encode()
-						// newDatabases[i].DBName = helpers.ParsedDBName(parsed.Path)
-						// newDatabases[i].DSN = parsed.DSN
+						// Start from the existing connection so fields not
+						// present on the form (Commands, Username, Password,
+						// Hostname, Port, URLParams, Schemas, ...) are preserved.
+						updated := database
+						updated.Name = parsedDatabaseData.Name
+						updated.Provider = parsedDatabaseData.Provider
+						updated.DBName = parsedDatabaseData.DBName
+						updated.URL = parsedDatabaseData.URL
+						updated.ReadOnly = parsedDatabaseData.ReadOnly
+						newDatabases[i] = updated
 					} else {
 						newDatabases[i] = database
 					}

--- a/models/models.go
+++ b/models/models.go
@@ -20,24 +20,24 @@ type Connection struct {
 	Name string
 
 	// either use this directly
-	URL string
+	URL string `toml:",omitempty"`
 
 	// or parse manually
-	Provider  string
-	Username  string
-	Password  string
-	Hostname  string
-	Port      string
-	DBName    string
-	URLParams string
+	Provider  string `toml:",omitempty"`
+	Username  string `toml:",omitempty"`
+	Password  string `toml:",omitempty"`
+	Hostname  string `toml:",omitempty"`
+	Port      string `toml:",omitempty"`
+	DBName    string `toml:",omitempty"`
+	URLParams string `toml:",omitempty"`
 
-	ReadOnly bool
+	ReadOnly bool `toml:",omitempty"`
 
 	// Schemas filters the schemas shown in the tree (PostgreSQL/MSSQL only).
 	// If empty, all schemas are shown.
-	Schemas []string
+	Schemas []string `toml:",omitempty"`
 
-	Commands []*Command
+	Commands []*Command `toml:",omitempty"`
 }
 
 type KeymapConfig map[string]map[string]string


### PR DESCRIPTION
## Problem

Editing an existing connection through the app's edit form silently drops
any fields that aren't shown on the form. The form only exposes **Name**,
**URL** and **Read-Only**, but on save it constructed a brand-new
`models.Connection` from just those values and **replaced** the original
entry entirely.

As a result, editing a connection:

- **loses** manually-configured fields — most notably `Commands` (init
  command), but also `Username`, `Password`, `Hostname`, `Port`,
  `URLParams` and `Schemas`, and
- **writes empty** `Port`/`Username`/`Password`/`Hostname` entries into the
  TOML even for connections that only ever had a `URL` set, since
  `models.Connection` had no `omitempty` tags and the encoder serialized
  every field.

## Fix

- In the edit handler (`components/connection_form.go`), start from the
  existing connection and only overwrite the form-backed fields
  (Name, Provider, DBName, URL, ReadOnly), so everything else is preserved.
  Also removes a stale commented-out block.
- Add `toml:",omitempty"` tags to optional `Connection` fields so empty
  values are no longer written to the config file.

## Testing

`go build ./...` passes.