### PR TITLE
feat: commands add shell syntax support

### DIFF
--- a/helpers/command.go
+++ b/helpers/command.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
-	"strings"
+	"runtime"
 	"time"
 
 	"github.com/mitchellh/go-linereader"
@@ -19,11 +19,12 @@ import (
 func RunCommand(ctx context.Context, command string, timeout time.Duration, doneFn func(output string)) error {
 	var cmd *exec.Cmd
 
-	parts := strings.Fields(command)
-	if len(parts) == 1 {
-		cmd = exec.CommandContext(ctx, parts[0]) // #nosec G204
+	// Run the command through the platform shell so configured commands support
+	// shell syntax such as quoting, pipes, redirects, and logical operators.
+	if runtime.GOOS == "windows" {
+		cmd = exec.CommandContext(ctx, "cmd.exe", "/C", command)
 	} else {
-		cmd = exec.CommandContext(ctx, parts[0], parts[1:]...) // #nosec G204
+		cmd = exec.CommandContext(ctx, "sh", "-c", command)
 	}
 
 	// Create a pipe to read the output from.

--- a/helpers/command.go
+++ b/helpers/command.go
@@ -22,9 +22,9 @@ func RunCommand(ctx context.Context, command string, timeout time.Duration, done
 	// Run the command through the platform shell so configured commands support
 	// shell syntax such as quoting, pipes, redirects, and logical operators.
 	if runtime.GOOS == "windows" {
-		cmd = exec.CommandContext(ctx, "cmd.exe", "/C", command)
+		cmd = exec.CommandContext(ctx, "cmd.exe", "/C", command) // #nosec G204
 	} else {
-		cmd = exec.CommandContext(ctx, "sh", "-c", command)
+		cmd = exec.CommandContext(ctx, "sh", "-c", command) // #nosec G204
 	}
 
 	// Create a pipe to read the output from.

--- a/helpers/command_test.go
+++ b/helpers/command_test.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"context"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -129,5 +130,57 @@ func TestRunCommand_OutputCapture(t *testing.T) {
 		}
 	case <-time.After(6 * time.Second):
 		t.Error("timeout waiting for output")
+	}
+}
+
+func TestRunCommand_SupportsQuotedArgs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("quoted shell syntax test is Unix-specific")
+	}
+
+	ctx := context.Background()
+	done := make(chan string, 1)
+
+	err := RunCommand(ctx, "printf '%s' 'hello world'", 5*time.Second, func(output string) {
+		done <- output
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	select {
+	case output := <-done:
+		if output != "hello world" {
+			t.Fatalf("expected exact quoted arg output %q, got %q", "hello world", output)
+		}
+	case <-time.After(6 * time.Second):
+		t.Fatal("timeout waiting for output")
+	}
+}
+
+func TestRunCommand_SupportsLogicalOperators(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("logical shell operator test is Unix-specific")
+	}
+
+	ctx := context.Background()
+	done := make(chan string, 1)
+
+	err := RunCommand(ctx, "false || printf '%s' fallback", 5*time.Second, func(output string) {
+		done <- output
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	select {
+	case output := <-done:
+		if output != "fallback" {
+			t.Fatalf("expected logical operator fallback output %q, got %q", "fallback", output)
+		}
+	case <-time.After(6 * time.Second):
+		t.Fatal("timeout waiting for output")
 	}
 }


### PR DESCRIPTION
This PR changes Command to behave more like a shell Command as described in the README.

using ` sh -c` on UNIX and `cmd /C` on windows the Command in a config can now contain

```
// Logical Operators
{ Command = 'rbw unlocked && rbw get db || exit 1', SaveOutputTo = 'password' },
// Quoted Arguments
{ Command = 'grep -i "the whole password is:"', SaveOutputTo = 'password' },
```

Closes #314 