### PR TITLE
feat(vim): add 'e' keybinding for end-of-word movement

### DIFF
--- a/components/sql_editor.go
+++ b/components/sql_editor.go
@@ -424,6 +424,8 @@ func (e *SQLEditor) handleNormalMode(event *tcell.EventKey) {
 			e.moveRight()
 		case 'w':
 			e.wordForward()
+		case 'e':
+			e.wordEnd()
 		case 'b':
 			e.wordBackward()
 		case '0':
@@ -556,6 +558,8 @@ func (e *SQLEditor) handleVisualMode(event *tcell.EventKey) {
 			e.moveRight()
 		case 'w':
 			e.wordForward()
+		case 'e':
+			e.wordEnd()
 		case 'b':
 			e.wordBackward()
 		case '0':
@@ -928,6 +932,32 @@ func (e *SQLEditor) wordForward() {
 	for e.cx < len(line) && line[e.cx] != ' ' && line[e.cx] != '\t' {
 		e.cx++
 	}
+}
+
+func (e *SQLEditor) wordEnd() {
+	line := e.lines[e.cy]
+	cx := e.cx
+	// Step over current position to seek next word end
+	cx++
+	if cx >= len(line) {
+		if e.cy < len(e.lines)-1 {
+			e.cy++
+			e.cx = 0
+			line = e.lines[e.cy]
+			cx = 0
+		} else {
+			return
+		}
+	}
+	// Skip whitespace
+	for cx < len(line) && (line[cx] == ' ' || line[cx] == '\t') {
+		cx++
+	}
+	// Move to end of word
+	for cx < len(line)-1 && line[cx+1] != ' ' && line[cx+1] != '\t' {
+		cx++
+	}
+	e.cx = cx
 }
 
 func (e *SQLEditor) wordBackward() {


### PR DESCRIPTION
## Summary

- `e` key in vim normal mode moves cursor to end of the current word (or end of next word if already at word end), matching standard vim behavior
- Same binding added to visual mode for consistency
- Adds new `wordEnd()` method to `SQLEditor`

## Root cause

`handleNormalMode()` and `handleVisualMode()` had `w` (word forward) and `b` (word backward) but `e` was never implemented. The key fell through the switch silently.

## Changes

- `components/sql_editor.go`: add `case 'e': e.wordEnd()` in both normal and visual mode switch statements
- `components/sql_editor.go`: add `wordEnd()` method — skips whitespace then advances to last non-whitespace char of the word

## Test

1. Open lazysql, focus SQL editor, press `Ctrl+E` to enter vim normal mode
2. Place cursor at start of a word
3. Press `e` — cursor moves to last character of that word
4. Press `e` again at word end — cursor moves to end of next word