### PR TITLE
 feat(mssql): support schema-qualified tree items

### DIFF
--- a/components/tree.go
+++ b/components/tree.go
@@ -173,49 +173,7 @@ func NewTree(dbName string, dbdriver drivers.Driver, schemas []string) *Tree {
 	})
 
 	tree.SetSelectedFunc(func(node *tview.TreeNode) {
-		nodeData := tree.GetTreeNodeData(node)
-
-		switch nodeData.Type {
-		case NodeTypeSection:
-			node.SetExpanded(!node.IsExpanded())
-		case NodeTypeDatabase:
-			if node.IsExpanded() {
-				node.SetExpanded(false)
-			} else {
-				tree.SetSelectedDatabase(nodeData.Database)
-				node.SetExpanded(true)
-			}
-		case NodeTypeTable:
-			tree.SetSelectedDatabase(nodeData.Database)
-			if nodeData.Schema == "" {
-				tree.SetSelectedTable(nodeData.Name)
-			} else {
-				tree.SetSelectedTable(fmt.Sprintf("%s.%s", nodeData.Schema, nodeData.Name))
-			}
-		case NodeTypeProcedure:
-			tree.SetSelectedDatabase(nodeData.Database)
-			if nodeData.Schema == "" {
-				tree.SetSelectedProcedure(nodeData.Name)
-			} else {
-				tree.SetSelectedProcedure(fmt.Sprintf("%s.%s", nodeData.Schema, nodeData.Name))
-			}
-		case NodeTypeFunction:
-			tree.SetSelectedDatabase(nodeData.Database)
-			if nodeData.Schema == "" {
-				tree.SetSelectedUserDefinedFunction(nodeData.Name)
-			} else {
-				tree.SetSelectedUserDefinedFunction(fmt.Sprintf("%s.%s", nodeData.Schema, nodeData.Name))
-			}
-		case NodeTypeView:
-			tree.SetSelectedDatabase(nodeData.Database)
-			if nodeData.Schema == "" {
-				tree.SetSelectedView(nodeData.Name)
-			} else {
-				tree.SetSelectedView(fmt.Sprintf("%s.%s", nodeData.Schema, nodeData.Name))
-			}
-		default:
-			break
-		}
+		tree.handleSelectedNode(node)
 	})
 
 	tree.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
@@ -412,120 +370,121 @@ func (tree *Tree) databasesToNodes(children map[string][]string, node *tview.Tre
 	}
 }
 
-// buildSchemaTree builds the complete per-schema subtree for a database node.
-// Each schema gets a node with "tables", and optionally "functions", "procedures", "views" sections.
-// The functions/procedures/views maps are keyed by database name and contain schema-qualified names.
-func (tree *Tree) buildSchemaTree(database string, node *tview.TreeNode, tables, functions, procedures, views map[string][]string) {
-	supportsProgramming := tree.DBDriver.SupportsProgramming()
+type qualifiedTreeObject struct {
+	Schema string
+	Name   string
+}
 
-	// Collect unique schema names from tables and, when supported, from
-	// functions/procedures/views (whose values are "schema.name" strings).
-	schemaSet := make(map[string]struct{})
-	for k := range tables {
-		schemaSet[k] = struct{}{}
+func (tree *Tree) handleSelectedNode(node *tview.TreeNode) {
+	nodeData := tree.GetTreeNodeData(node)
+	qualifiedName := nodeData.Name
+	if nodeData.Schema != "" {
+		qualifiedName = fmt.Sprintf("%s.%s", nodeData.Schema, nodeData.Name)
 	}
-	if supportsProgramming {
-		for _, items := range functions[database] {
-			if idx := strings.IndexByte(items, '.'); idx > 0 {
-				schemaSet[items[:idx]] = struct{}{}
-			}
-		}
-		for _, items := range procedures[database] {
-			if idx := strings.IndexByte(items, '.'); idx > 0 {
-				schemaSet[items[:idx]] = struct{}{}
-			}
-		}
-		for _, items := range views[database] {
-			if idx := strings.IndexByte(items, '.'); idx > 0 {
-				schemaSet[items[:idx]] = struct{}{}
-			}
-		}
-	}
-	sortedKeys := slices.Sorted(maps.Keys(schemaSet))
 
-	for _, schema := range sortedKeys {
-		// Filter schemas if Schemas is configured
-		if len(tree.Schemas) > 0 {
-			found := false
-			for _, s := range tree.Schemas {
-				if s == schema {
-					found = true
-					break
-				}
-			}
-			if !found {
-				continue
-			}
-		}
-
-		schemaNode := tview.NewTreeNode(schema)
-		schemaNode.SetExpanded(false)
-		schemaNode.SetReference(schema)
-		schemaNode.SetColor(app.Styles.PrimaryTextColor)
-		node.AddChild(schemaNode)
-
-		if supportsProgramming {
-			tablesNode := tview.NewTreeNode("tables")
-			tablesNode.SetExpanded(false)
-			tablesNode.SetReference(fmt.Sprintf("%s.tables", schema))
-			tablesNode.SetColor(app.Styles.PrimaryTextColor)
-			schemaNode.AddChild(tablesNode)
-
-			for _, child := range tables[schema] {
-				childNode := tview.NewTreeNode(child)
-				childNode.SetExpanded(true)
-				childNode.SetColor(app.Styles.PrimaryTextColor)
-				childNode.SetReference(fmt.Sprintf("%s.%s.tables.%s", database, schema, child))
-				tablesNode.AddChild(childNode)
-			}
+	switch nodeData.Type {
+	case NodeTypeSection:
+		node.SetExpanded(!node.IsExpanded())
+	case NodeTypeDatabase:
+		if node.IsExpanded() {
+			node.SetExpanded(false)
 		} else {
-			for _, child := range tables[schema] {
-				childNode := tview.NewTreeNode(child)
-				childNode.SetExpanded(true)
-				childNode.SetColor(app.Styles.PrimaryTextColor)
-				childNode.SetReference(fmt.Sprintf("%s.%s.%s", database, schema, child))
-				schemaNode.AddChild(childNode)
-			}
+			tree.SetSelectedDatabase(nodeData.Database)
+			node.SetExpanded(true)
 		}
-
-		if supportsProgramming {
-			tree.addSchemaProgrammingSection(schemaNode, database, schema, "functions", functions)
-			tree.addSchemaProgrammingSection(schemaNode, database, schema, "procedures", procedures)
-			tree.addSchemaProgrammingSection(schemaNode, database, schema, "views", views)
-		}
+	case NodeTypeTable:
+		tree.SetSelectedDatabase(nodeData.Database)
+		tree.SetSelectedTable(qualifiedName)
+	case NodeTypeProcedure:
+		tree.SetSelectedDatabase(nodeData.Database)
+		tree.SetSelectedProcedure(qualifiedName)
+	case NodeTypeFunction:
+		tree.SetSelectedDatabase(nodeData.Database)
+		tree.SetSelectedUserDefinedFunction(qualifiedName)
+	case NodeTypeView:
+		tree.SetSelectedDatabase(nodeData.Database)
+		tree.SetSelectedView(qualifiedName)
 	}
 }
 
-// addSchemaProgrammingSection adds a single programming section (e.g. "functions") under a schema node.
-// It filters items from the programmingMap that belong to the given schema (schema-qualified names).
-func (tree *Tree) addSchemaProgrammingSection(schemaNode *tview.TreeNode, database, schema, section string, programmingMap map[string][]string) {
-	prefix := schema + "."
-	var items []string
-	for _, qualified := range programmingMap[database] {
-		if strings.HasPrefix(qualified, prefix) {
-			items = append(items, strings.TrimPrefix(qualified, prefix))
+func (tree *Tree) buildQualifiedCategoryTree(database string, node *tview.TreeNode, tables, functions, procedures, views map[string][]string) {
+	node.ClearChildren()
+
+	tree.addQualifiedCategoryNode(node, database, "tables", tree.flattenQualifiedTableObjects(tables))
+	tree.addQualifiedCategoryNode(node, database, "functions", tree.flattenQualifiedObjects(functions[database]))
+	tree.addQualifiedCategoryNode(node, database, "procedures", tree.flattenQualifiedObjects(procedures[database]))
+	tree.addQualifiedCategoryNode(node, database, "views", tree.flattenQualifiedObjects(views[database]))
+}
+
+func (tree *Tree) addQualifiedCategoryNode(parent *tview.TreeNode, database, section string, objects []qualifiedTreeObject) {
+	sectionNode := tview.NewTreeNode(section)
+	sectionNode.SetExpanded(false)
+	sectionNode.SetReference(fmt.Sprintf("%s.%s", database, section))
+	sectionNode.SetColor(app.Styles.PrimaryTextColor)
+	parent.AddChild(sectionNode)
+
+	for _, object := range objects {
+		itemNode := tview.NewTreeNode(fmt.Sprintf("%s.%s", object.Schema, object.Name))
+		itemNode.SetExpanded(false)
+		itemNode.SetColor(app.Styles.PrimaryTextColor)
+		itemNode.SetReference(fmt.Sprintf("%s.%s.%s.%s", database, object.Schema, section, object.Name))
+		sectionNode.AddChild(itemNode)
+	}
+}
+
+func (tree *Tree) flattenQualifiedTableObjects(tables map[string][]string) []qualifiedTreeObject {
+	objects := make([]qualifiedTreeObject, 0)
+	for schema, names := range tables {
+		if !tree.includeSchema(schema) {
+			continue
+		}
+
+		for _, name := range names {
+			objects = append(objects, qualifiedTreeObject{Schema: schema, Name: name})
 		}
 	}
 
-	if len(items) == 0 {
-		return
+	sort.Slice(objects, func(i, j int) bool {
+		left := fmt.Sprintf("%s.%s", objects[i].Schema, objects[i].Name)
+		right := fmt.Sprintf("%s.%s", objects[j].Schema, objects[j].Name)
+		return left < right
+	})
+
+	return objects
+}
+
+func (tree *Tree) flattenQualifiedObjects(names []string) []qualifiedTreeObject {
+	objects := make([]qualifiedTreeObject, 0, len(names))
+	for _, qualifiedName := range names {
+		schema, name, err := drivers.ParseSchemaQualifiedName(qualifiedName)
+		if err != nil || !tree.includeSchema(schema) {
+			continue
+		}
+
+		objects = append(objects, qualifiedTreeObject{Schema: schema, Name: name})
 	}
 
-	sort.Strings(items)
+	sort.Slice(objects, func(i, j int) bool {
+		left := fmt.Sprintf("%s.%s", objects[i].Schema, objects[i].Name)
+		right := fmt.Sprintf("%s.%s", objects[j].Schema, objects[j].Name)
+		return left < right
+	})
 
-	sectionNode := tview.NewTreeNode(section)
-	sectionNode.SetExpanded(false)
-	sectionNode.SetReference(fmt.Sprintf("%s.%s.%s", database, schema, section))
-	sectionNode.SetColor(app.Styles.PrimaryTextColor)
-	schemaNode.AddChild(sectionNode)
+	return objects
+}
 
-	for _, item := range items {
-		itemNode := tview.NewTreeNode(item)
-		itemNode.SetExpanded(false)
-		itemNode.SetColor(app.Styles.PrimaryTextColor)
-		itemNode.SetReference(fmt.Sprintf("%s.%s.%s.%s", database, schema, section, item))
-		sectionNode.AddChild(itemNode)
+func (tree *Tree) includeSchema(schema string) bool {
+	if len(tree.Schemas) == 0 {
+		return true
 	}
+
+	for _, configuredSchema := range tree.Schemas {
+		if configuredSchema == schema {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (tree *Tree) addProgrammingNodes(functions map[string][]string, procedures map[string][]string, views map[string][]string, node *tview.TreeNode) {
@@ -1045,7 +1004,11 @@ func (tree *Tree) InitializeNodes(dbName string) {
 			}
 
 			if useSchemas {
-				tree.buildSchemaTree(database, node, tables, functions, procedures, views)
+				if supportsProgramming {
+					tree.buildQualifiedCategoryTree(database, node, tables, functions, procedures, views)
+				} else {
+					tree.databasesToNodes(tables, node, true)
+				}
 			} else {
 				tree.databasesToNodes(tables, node, true)
 				if supportsProgramming {

--- a/components/tree_test.go
+++ b/components/tree_test.go
@@ -297,8 +297,6 @@ func TestExpandAncestors_AlreadyExpanded(t *testing.T) {
 
 // ── schemaProgrammingMock ───────────────────────────────────────────────────────
 // Implements drivers.Driver with SupportsProgramming()=true and UseSchemas()=true.
-// Used to test buildSchemaTree, addSchemaProgrammingSection, and the new
-// GetTreeNodeData paths.
 
 var _ drivers.Driver = (*schemaProgrammingMock)(nil)
 
@@ -354,209 +352,93 @@ func (m *schemaProgrammingMock) DMLChangeToQueryString(models.DBDMLChange) (stri
 }
 func (m *schemaProgrammingMock) SetProvider(string) {}
 
-// ── buildSchemaTree tests ───────────────────────────────────────────────────────
+// ── qualified category tree tests ──────────────────────────────────────────────
 
-func TestBuildSchemaTree_BasicStructure(t *testing.T) {
+func TestBuildQualifiedCategoryTree_PreservesCategoryNodesAndQualifiedLabels(t *testing.T) {
 	tree := &Tree{DBDriver: &schemaProgrammingMock{}}
 
 	dbNode := tview.NewTreeNode("mydb")
 	dbNode.SetReference("mydb")
 
-	tables := map[string][]string{"public": {"users", "posts"}}
-	functions := map[string][]string{"mydb": {"public.add_user"}}
-	procedures := map[string][]string{"mydb": {"public.cleanup"}}
-	views := map[string][]string{"mydb": {"public.user_view"}}
+	tables := map[string][]string{
+		"dbo":   {"users"},
+		"sales": {"orders", "users"},
+	}
+	functions := map[string][]string{"mydb": {"dbo.add_user", "sales.add_user"}}
+	procedures := map[string][]string{"mydb": {"dbo.cleanup"}}
+	views := map[string][]string{"mydb": {"sales.active_users"}}
 
-	tree.buildSchemaTree("mydb", dbNode, tables, functions, procedures, views)
+	tree.buildQualifiedCategoryTree("mydb", dbNode, tables, functions, procedures, views)
 
-	// ── db node has 1 child (schema "public") ──
 	children := dbNode.GetChildren()
-	if len(children) != 1 {
-		t.Fatalf("expected 1 child (schema) under db node, got %d", len(children))
-	}
-
-	schemaNode := children[0]
-	if schemaNode.GetText() != "public" {
-		t.Errorf("expected schema node text 'public', got '%s'", schemaNode.GetText())
-	}
-
-	// ── schema node has 4 children: tables, functions, procedures, views ──
-	schemaChildren := schemaNode.GetChildren()
-	if len(schemaChildren) != 4 {
-		t.Fatalf("expected 4 children under schema node, got %d", len(schemaChildren))
+	if len(children) != 4 {
+		t.Fatalf("expected 4 category nodes, got %d", len(children))
 	}
 
 	sectionNames := []string{"tables", "functions", "procedures", "views"}
 	for i, name := range sectionNames {
-		if schemaChildren[i].GetText() != name {
-			t.Errorf("expected section %d text '%s', got '%s'", i, name, schemaChildren[i].GetText())
+		if children[i].GetText() != name {
+			t.Fatalf("expected category %d to be %q, got %q", i, name, children[i].GetText())
 		}
 	}
 
-	// ── "tables" section has 2 children: "users", "posts" ──
-	tablesSection := schemaChildren[0]
-	tableChildren := tablesSection.GetChildren()
-	if len(tableChildren) != 2 {
-		t.Fatalf("expected 2 table children, got %d", len(tableChildren))
-	}
-	if tableChildren[0].GetText() != "users" {
-		t.Errorf("expected first table 'users', got '%s'", tableChildren[0].GetText())
-	}
-	if tableChildren[1].GetText() != "posts" {
-		t.Errorf("expected second table 'posts', got '%s'", tableChildren[1].GetText())
-	}
-	if tableChildren[0].GetReference().(string) != "mydb.public.tables.users" {
-		t.Errorf("expected table reference 'mydb.public.tables.users', got '%s'", tableChildren[0].GetReference().(string))
-	}
-	if tableChildren[1].GetReference().(string) != "mydb.public.tables.posts" {
-		t.Errorf("expected table reference 'mydb.public.tables.posts', got '%s'", tableChildren[1].GetReference().(string))
+	tableChildren := children[0].GetChildren()
+	if len(tableChildren) != 3 {
+		t.Fatalf("expected 3 tables, got %d", len(tableChildren))
 	}
 
-	// ── "functions" section has 1 child: "add_user" (NOT "public.add_user") ──
-	functionsSection := schemaChildren[1]
-	funcChildren := functionsSection.GetChildren()
-	if len(funcChildren) != 1 {
-		t.Fatalf("expected 1 function child, got %d", len(funcChildren))
+	if tableChildren[0].GetText() != "dbo.users" || tableChildren[0].GetReference().(string) != "mydb.dbo.tables.users" {
+		t.Fatalf("expected first table to be dbo.users with qualified reference, got %q / %q", tableChildren[0].GetText(), tableChildren[0].GetReference().(string))
 	}
-	if funcChildren[0].GetText() != "add_user" {
-		t.Errorf("expected function 'add_user', got '%s'", funcChildren[0].GetText())
+	if tableChildren[1].GetText() != "sales.orders" || tableChildren[1].GetReference().(string) != "mydb.sales.tables.orders" {
+		t.Fatalf("expected second table to be sales.orders with qualified reference, got %q / %q", tableChildren[1].GetText(), tableChildren[1].GetReference().(string))
 	}
-	if funcChildren[0].GetReference().(string) != "mydb.public.functions.add_user" {
-		t.Errorf("expected reference 'mydb.public.functions.add_user', got '%s'", funcChildren[0].GetReference().(string))
+	if tableChildren[2].GetText() != "sales.users" || tableChildren[2].GetReference().(string) != "mydb.sales.tables.users" {
+		t.Fatalf("expected third table to be sales.users with qualified reference, got %q / %q", tableChildren[2].GetText(), tableChildren[2].GetReference().(string))
 	}
 
-	// ── "procedures" section has 1 child: "cleanup" ──
-	proceduresSection := schemaChildren[2]
-	procChildren := proceduresSection.GetChildren()
-	if len(procChildren) != 1 {
-		t.Fatalf("expected 1 procedure child, got %d", len(procChildren))
+	functionChildren := children[1].GetChildren()
+	if len(functionChildren) != 2 {
+		t.Fatalf("expected 2 functions, got %d", len(functionChildren))
 	}
-	if procChildren[0].GetText() != "cleanup" {
-		t.Errorf("expected procedure 'cleanup', got '%s'", procChildren[0].GetText())
-	}
-	if procChildren[0].GetReference().(string) != "mydb.public.procedures.cleanup" {
-		t.Errorf("expected reference 'mydb.public.procedures.cleanup', got '%s'", procChildren[0].GetReference().(string))
-	}
-
-	// ── "views" section has 1 child: "user_view" ──
-	viewsSection := schemaChildren[3]
-	viewChildren := viewsSection.GetChildren()
-	if len(viewChildren) != 1 {
-		t.Fatalf("expected 1 view child, got %d", len(viewChildren))
-	}
-	if viewChildren[0].GetText() != "user_view" {
-		t.Errorf("expected view 'user_view', got '%s'", viewChildren[0].GetText())
-	}
-	if viewChildren[0].GetReference().(string) != "mydb.public.views.user_view" {
-		t.Errorf("expected reference 'mydb.public.views.user_view', got '%s'", viewChildren[0].GetReference().(string))
+	if functionChildren[0].GetText() != "dbo.add_user" || functionChildren[1].GetText() != "sales.add_user" {
+		t.Fatalf("expected qualified function labels, got %q and %q", functionChildren[0].GetText(), functionChildren[1].GetText())
 	}
 }
 
-// TestBuildSchemaTree_SchemaWithOnlyFunctions validates that schemas containing
-// only programming objects (functions/procedures/views) but no tables still
-// appear in the tree. On this branch, buildSchemaTree collects schema names
-// from all maps (tables + functions/procedures/views), so "api" appears even
-// though it has no tables.
-func TestBuildSchemaTree_SchemaWithOnlyFunctions(t *testing.T) {
-	tree := &Tree{DBDriver: &schemaProgrammingMock{}}
+func TestBuildQualifiedCategoryTree_RespectsSchemaFilter(t *testing.T) {
+	tree := &Tree{DBDriver: &schemaProgrammingMock{}, Schemas: []string{"sales"}}
 
 	dbNode := tview.NewTreeNode("mydb")
 	dbNode.SetReference("mydb")
 
-	tables := map[string][]string{"public": {"users"}}
-	functions := map[string][]string{"mydb": {"api.get_data"}}
-	procedures := map[string][]string{}
-	views := map[string][]string{}
+	tree.buildQualifiedCategoryTree(
+		"mydb",
+		dbNode,
+		map[string][]string{"dbo": {"users"}, "sales": {"orders"}},
+		map[string][]string{"mydb": {"dbo.add_user", "sales.add_user"}},
+		map[string][]string{},
+		map[string][]string{},
+	)
 
-	tree.buildSchemaTree("mydb", dbNode, tables, functions, procedures, views)
-
-	children := dbNode.GetChildren()
-
-	// Expect both "api" (from functions) and "public" (from tables)
-	if len(children) != 2 {
-		t.Fatalf("expected 2 schema children (api, public), got %d", len(children))
+	tableChildren := dbNode.GetChildren()[0].GetChildren()
+	if len(tableChildren) != 1 || tableChildren[0].GetText() != "sales.orders" {
+		t.Fatalf("expected only sales.orders after schema filtering, got %#v", tableChildren)
 	}
 
-	// Sorted keys: ["api", "public"] — "api" comes first alphabetically
-	apiNode := children[0]
-	if apiNode.GetText() != "api" {
-		t.Errorf("expected first schema 'api', got '%s'", apiNode.GetText())
-	}
-
-	// "api" has a "tables" section (created unconditionally when supportsProgramming)
-	// plus a "functions" section with "get_data"
-	apiChildren := apiNode.GetChildren()
-	if len(apiChildren) != 2 {
-		t.Fatalf("expected 2 children under 'api' (tables + functions), got %d", len(apiChildren))
-	}
-	if apiChildren[0].GetText() != "tables" {
-		t.Errorf("expected 'tables' section under 'api', got '%s'", apiChildren[0].GetText())
-	}
-	if apiChildren[1].GetText() != "functions" {
-		t.Errorf("expected 'functions' section under 'api', got '%s'", apiChildren[1].GetText())
-	}
-
-	// "api" tables section should have no children (no tables for "api")
-	if len(apiChildren[0].GetChildren()) != 0 {
-		t.Errorf("expected no tables under 'api', got %d", len(apiChildren[0].GetChildren()))
-	}
-
-	// Verify the function item
-	funcSection := apiChildren[1]
-	funcItems := funcSection.GetChildren()
-	if len(funcItems) != 1 {
-		t.Fatalf("expected 1 function under api, got %d", len(funcItems))
-	}
-	if funcItems[0].GetText() != "get_data" {
-		t.Errorf("expected function 'get_data', got '%s'", funcItems[0].GetText())
-	}
-
-	// Second child: "public" has tables but no matching functions/procedures/views
-	publicNode := children[1]
-	if publicNode.GetText() != "public" {
-		t.Errorf("expected second schema 'public', got '%s'", publicNode.GetText())
-	}
-	publicChildren := publicNode.GetChildren()
-	if len(publicChildren) != 1 {
-		t.Fatalf("expected 1 child under 'public' (just tables), got %d", len(publicChildren))
-	}
-	if publicChildren[0].GetText() != "tables" {
-		t.Errorf("expected 'tables' section under 'public', got '%s'", publicChildren[0].GetText())
-	}
-	if len(publicChildren[0].GetChildren()) != 1 {
-		t.Fatalf("expected 1 table under 'public', got %d", len(publicChildren[0].GetChildren()))
-	}
-	if publicChildren[0].GetChildren()[0].GetText() != "users" {
-		t.Errorf("expected table 'users', got '%s'", publicChildren[0].GetChildren()[0].GetText())
-	}
-}
-
-// ── addSchemaProgrammingSection tests ───────────────────────────────────────────
-
-func TestAddSchemaProgrammingSection_EmptySection(t *testing.T) {
-	tree := &Tree{DBDriver: &schemaProgrammingMock{}}
-
-	schemaNode := tview.NewTreeNode("public")
-	schemaNode.SetReference("public")
-
-	// programmingMap with no items for the "public" schema
-	programmingMap := map[string][]string{"mydb": {"other_schema.some_func"}}
-
-	tree.addSchemaProgrammingSection(schemaNode, "mydb", "public", "functions", programmingMap)
-
-	// No child should have been added because no items matched the prefix "public."
-	if len(schemaNode.GetChildren()) != 0 {
-		t.Errorf("expected no children added for empty section, got %d", len(schemaNode.GetChildren()))
+	functionChildren := dbNode.GetChildren()[1].GetChildren()
+	if len(functionChildren) != 1 || functionChildren[0].GetText() != "sales.add_user" {
+		t.Fatalf("expected only sales.add_user after schema filtering, got %#v", functionChildren)
 	}
 }
 
 // ── GetTreeNodeData schema programming tests ────────────────────────────────────
 
-func TestGetTreeNodeDataSchemaProgramming_SectionHeader(t *testing.T) {
+func TestGetTreeNodeDataQualifiedCategorySectionHeader(t *testing.T) {
 	tree := &Tree{DBDriver: &schemaProgrammingMock{}}
 
 	node := tview.NewTreeNode("functions")
-	node.SetReference("mydb.public.functions")
+	node.SetReference("mydb.functions")
 
 	data := tree.GetTreeNodeData(node)
 
@@ -566,8 +448,8 @@ func TestGetTreeNodeDataSchemaProgramming_SectionHeader(t *testing.T) {
 	if data.Database != "mydb" {
 		t.Errorf("expected Database 'mydb', got '%s'", data.Database)
 	}
-	if data.Schema != "public" {
-		t.Errorf("expected Schema 'public', got '%s'", data.Schema)
+	if data.Schema != "" {
+		t.Errorf("expected empty Schema, got '%s'", data.Schema)
 	}
 	if data.Name != "functions" {
 		t.Errorf("expected Name 'functions', got '%s'", data.Name)
@@ -577,7 +459,7 @@ func TestGetTreeNodeDataSchemaProgramming_SectionHeader(t *testing.T) {
 func TestGetTreeNodeDataSchemaProgramming_ItemNode(t *testing.T) {
 	tree := &Tree{DBDriver: &schemaProgrammingMock{}}
 
-	node := tview.NewTreeNode("add_user")
+	node := tview.NewTreeNode("public.add_user")
 	node.SetReference("mydb.public.functions.add_user")
 
 	data := tree.GetTreeNodeData(node)
@@ -599,7 +481,7 @@ func TestGetTreeNodeDataSchemaProgramming_ItemNode(t *testing.T) {
 func TestGetTreeNodeDataSchemaProgramming_TableItem(t *testing.T) {
 	tree := &Tree{DBDriver: &schemaProgrammingMock{}}
 
-	node := tview.NewTreeNode("users")
+	node := tview.NewTreeNode("public.users")
 	node.SetReference("mydb.public.tables.users")
 
 	data := tree.GetTreeNodeData(node)
@@ -615,5 +497,55 @@ func TestGetTreeNodeDataSchemaProgramming_TableItem(t *testing.T) {
 	}
 	if data.Name != "users" {
 		t.Errorf("expected Name 'users', got '%s'", data.Name)
+	}
+}
+
+func TestHandleSelectedNodePublishesQualifiedTableName(t *testing.T) {
+	subscriber := make(chan models.StateChange, 2)
+	tree := &Tree{
+		DBDriver:    &schemaProgrammingMock{},
+		state:       &TreeState{},
+		subscribers: []chan models.StateChange{subscriber},
+	}
+
+	node := tview.NewTreeNode("sales.users")
+	node.SetReference("mydb.sales.tables.users")
+
+	tree.handleSelectedNode(node)
+
+	if got := tree.GetSelectedDatabase(); got != "mydb" {
+		t.Fatalf("expected selected database mydb, got %q", got)
+	}
+	if got := tree.GetSelectedTable(); got != "sales.users" {
+		t.Fatalf("expected selected table sales.users, got %q", got)
+	}
+
+	first := <-subscriber
+	second := <-subscriber
+	if first.Key != eventTreeSelectedDatabase || first.Value != "mydb" {
+		t.Fatalf("expected first event to select database, got %+v", first)
+	}
+	if second.Key != eventTreeSelectedTable || second.Value != "sales.users" {
+		t.Fatalf("expected second event to select qualified table, got %+v", second)
+	}
+}
+
+func TestHandleSelectedNodePublishesQualifiedFunctionName(t *testing.T) {
+	subscriber := make(chan models.StateChange, 2)
+	tree := &Tree{
+		DBDriver:    &schemaProgrammingMock{},
+		state:       &TreeState{},
+		subscribers: []chan models.StateChange{subscriber},
+	}
+
+	node := tview.NewTreeNode("sales.add_user")
+	node.SetReference("mydb.sales.functions.add_user")
+
+	tree.handleSelectedNode(node)
+
+	<-subscriber // database event
+	event := <-subscriber
+	if event.Key != eventTreeSelectedFunction || event.Value != "sales.add_user" {
+		t.Fatalf("expected qualified function event, got %+v", event)
 	}
 }

--- a/drivers/mssqql.go
+++ b/drivers/mssqql.go
@@ -116,9 +116,11 @@ func (db *MSSQL) GetTables(database string) (map[string][]string, error) {
 
 	tables := make(map[string][]string)
 
-	query := "SELECT name FROM "
+	query := "SELECT\n\t\t\ts.name AS schema_name,\n\t\t\tt.name AS table_name\n\t\tFROM "
 	query += database
-	query += ".sys.tables"
+	query += ".sys.tables t\n\t\tINNER JOIN "
+	query += database
+	query += ".sys.schemas s\n\t\t\tON t.schema_id = s.schema_id\n\t\tORDER BY s.name, t.name"
 
 	rows, err := db.Connection.Query(query)
 	if err != nil {
@@ -128,12 +130,12 @@ func (db *MSSQL) GetTables(database string) (map[string][]string, error) {
 	defer rows.Close()
 
 	for rows.Next() {
-		var table string
-		if err := rows.Scan(&table); err != nil {
+		var schemaName, table string
+		if err := rows.Scan(&schemaName, &table); err != nil {
 			return nil, err
 		}
 
-		tables[database] = append(tables[database], table)
+		tables[schemaName] = append(tables[schemaName], table)
 	}
 
 	if err := rows.Err(); err != nil {
@@ -143,7 +145,35 @@ func (db *MSSQL) GetTables(database string) (map[string][]string, error) {
 	return tables, nil
 }
 
+func (db *MSSQL) resolveSchemaQualifiedName(name string) (string, string, error) {
+	schemaName, objectName, err := ParseSchemaQualifiedName(name)
+	if err == nil {
+		return schemaName, objectName, nil
+	}
+
+	currentSchema, currentSchemaErr := db.getCurrentSchema()
+	if currentSchemaErr != nil {
+		return "", "", err
+	}
+
+	return currentSchema, name, nil
+}
+
+func formatSchemaQualifiedReference(reference string) string {
+	schema, name, err := ParseSchemaQualifiedName(reference)
+	if err != nil {
+		return fmt.Sprintf("[%s]", reference)
+	}
+
+	return fmt.Sprintf("[%s].[%s]", schema, name)
+}
+
 func (db *MSSQL) GetTableColumns(database, table string) ([][]string, error) {
+	qualifiedTable := table
+	if schemaName, tableName, err := ParseSchemaQualifiedName(table); err == nil {
+		qualifiedTable = fmt.Sprintf("[%s].[%s]", schemaName, tableName)
+	}
+
 	query := fmt.Sprintf(`
 		USE %s;
         SELECT
@@ -158,15 +188,15 @@ func (db *MSSQL) GetTableColumns(database, table string) ([][]string, error) {
         LEFT JOIN sys.extended_properties ep ON ep.major_id = c.object_id
             AND ep.minor_id = c.column_id
             AND ep.name = 'MS_Description'
-        WHERE c.object_id = OBJECT_ID(@p2)
-        AND t.name <> 'sysname'
-        ORDER BY c.column_id;
+	        WHERE c.object_id = OBJECT_ID(@p2)
+	        AND t.name <> 'sysname'
+	        ORDER BY c.column_id;
     `, database)
-	return db.getTableInformation(query, database, table, "")
+	return db.getTableInformation(query, database, qualifiedTable, "")
 }
 
 func (db *MSSQL) GetConstraints(database, table string) ([][]string, error) {
-	currentSchema, err := db.getCurrentSchema()
+	schemaName, tableName, err := db.resolveSchemaQualifiedName(table)
 	if err != nil {
 		return nil, err
 	}
@@ -188,14 +218,19 @@ func (db *MSSQL) GetConstraints(database, table string) ([][]string, error) {
         INNER JOIN sys.columns c
             ON ic.column_id = c.column_id
             AND ic.object_id = c.object_id
-        WHERE s.name = @p1
-          AND t.name = @p2
-          AND kc.type IN ('PK', 'UQ')  -- Primary keys and unique constraints
+	        WHERE s.name = @p1
+	          AND t.name = @p2
+	          AND kc.type IN ('PK', 'UQ')  -- Primary keys and unique constraints
     `, database)
-	return db.getTableInformation(query, currentSchema, table, "")
+	return db.getTableInformation(query, schemaName, tableName, "")
 }
 
 func (db *MSSQL) GetForeignKeys(database, table string) ([][]string, error) {
+	schemaName, tableName, err := db.resolveSchemaQualifiedName(table)
+	if err != nil {
+		return nil, err
+	}
+
 	query := fmt.Sprintf(`
 		USE %s;
         SELECT
@@ -218,16 +253,17 @@ func (db *MSSQL) GetForeignKeys(database, table string) ([][]string, error) {
             AND fkc.referenced_object_id = rc.object_id
         INNER JOIN sys.tables t
             ON fk.parent_object_id = t.object_id
-        INNER JOIN sys.schemas s
-            ON t.schema_id = s.schema_id
-        WHERE t.name = @p2
-          AND DB_NAME(DB_ID(@p1)) = @p1
+	        INNER JOIN sys.schemas s
+	            ON t.schema_id = s.schema_id
+	        WHERE t.name = @p2
+	          AND s.name = @p3
+	          AND DB_NAME(DB_ID(@p1)) = @p1
     `, database)
-	return db.getTableInformation(query, database, table, "")
+	return db.getTableInformation(query, database, tableName, schemaName)
 }
 
 func (db *MSSQL) GetIndexes(database, table string) ([][]string, error) {
-	currentSchema, err := db.getCurrentSchema()
+	schemaName, tableName, err := db.resolveSchemaQualifiedName(table)
 	if err != nil {
 		return nil, err
 	}
@@ -258,12 +294,12 @@ func (db *MSSQL) GetIndexes(database, table string) ([][]string, error) {
         INNER JOIN sys.columns c
             ON ic.column_id = c.column_id
             AND t.object_id = c.object_id
-        WHERE t.name = @p2
-          AND s.name = @p3
-          AND DB_ID(@p1) = d.database_id
-        ORDER BY i.type_desc
+	        WHERE t.name = @p2
+	          AND s.name = @p3
+	          AND DB_ID(@p1) = d.database_id
+	        ORDER BY i.type_desc
     `, database)
-	return db.getTableInformation(query, database, table, currentSchema)
+	return db.getTableInformation(query, database, tableName, schemaName)
 }
 
 func (db *MSSQL) GetRecords(database, table, where, sort string, offset, limit int) (results [][]string, totalRecords int, displayQueryString string, err error) {
@@ -566,7 +602,7 @@ func (db *MSSQL) GetPrimaryKeyColumnNames(database, table string) ([]string, err
 		return nil, errors.New("table name is required")
 	}
 
-	currentSchema, err := db.getCurrentSchema()
+	schemaName, tableName, err := db.resolveSchemaQualifiedName(table)
 	if err != nil {
 		return nil, err
 	}
@@ -600,7 +636,7 @@ func (db *MSSQL) GetPrimaryKeyColumnNames(database, table string) ([]string, err
 			AND t.name = @p3
 		ORDER BY ic.key_ordinal
 	`
-	rows, err := db.Connection.Query(query, "PK", currentSchema, table)
+	rows, err := db.Connection.Query(query, "PK", schemaName, tableName)
 	if err != nil {
 		return nil, err
 	}
@@ -772,7 +808,7 @@ func (db *MSSQL) FormatArgForQueryString(arg any) string {
 }
 
 func (db *MSSQL) FormatReference(reference string) string {
-	return fmt.Sprintf("[%s]", reference)
+	return formatSchemaQualifiedReference(reference)
 }
 
 func (db *MSSQL) FormatPlaceholder(index int) string {
@@ -821,15 +857,18 @@ func (db *MSSQL) GetFunctions(database string) (map[string][]string, error) {
 
 	query := "USE "
 	query += database
-	query += ";"
+	query += ";\n"
 	query += `
-		SELECT o.name
-		FROM sys.sql_modules m
-		JOIN sys.objects o ON m.object_id = o.object_id
-		WHERE o.type_desc IN ('SQL_SCALAR_FUNCTION', 'SQL_TABLE_VALUED_FUNCTION')
+		SELECT
+			s.name + '.' + o.name AS qualified_name
+		FROM sys.objects o
+		INNER JOIN sys.schemas s
+			ON o.schema_id = s.schema_id
+		WHERE o.type_desc IN ('SQL_SCALAR_FUNCTION', 'SQL_TABLE_VALUED_FUNCTION', 'SQL_INLINE_TABLE_VALUED_FUNCTION')
+		ORDER BY s.name, o.name
 		`
 
-	rows, err := db.Connection.Query(query, database)
+	rows, err := db.Connection.Query(query)
 	if err != nil {
 		return nil, err
 	}
@@ -861,12 +900,15 @@ func (db *MSSQL) GetProcedures(database string) (map[string][]string, error) {
 
 	query := "USE "
 	query += database
-	query += "; "
+	query += ";\n"
 	query += `
-		SELECT o.name
-		FROM sys.sql_modules m
-		JOIN sys.objects o ON m.object_id = o.object_id
+		SELECT
+			s.name + '.' + o.name AS qualified_name
+		FROM sys.objects o
+		INNER JOIN sys.schemas s
+			ON o.schema_id = s.schema_id
 		WHERE o.type_desc IN ('SQL_STORED_PROCEDURE')
+		ORDER BY s.name, o.name
 		`
 
 	rows, err := db.Connection.Query(query)
@@ -897,7 +939,7 @@ func (db *MSSQL) SupportsProgramming() bool {
 }
 
 func (db *MSSQL) UseSchemas() bool {
-	return false
+	return true
 }
 
 func (db *MSSQL) GetViews(database string) (map[string][]string, error) {
@@ -909,12 +951,15 @@ func (db *MSSQL) GetViews(database string) (map[string][]string, error) {
 
 	query := "USE "
 	query += database
-	query += "; "
+	query += ";\n"
 	query += `
-		SELECT o.name
-		FROM sys.sql_modules m
-		JOIN sys.objects o ON m.object_id = o.object_id
+		SELECT
+			s.name + '.' + o.name AS qualified_name
+		FROM sys.objects o
+		INNER JOIN sys.schemas s
+			ON o.schema_id = s.schema_id
 		WHERE o.type_desc IN ('VIEW')
+		ORDER BY s.name, o.name
 	`
 
 	rows, err := db.Connection.Query(query)
@@ -944,8 +989,15 @@ func (db *MSSQL) GetObjectDefinition(database string, name string) (string, erro
 	if database == "" {
 		return "", errors.New("database name is required")
 	}
+	if name == "" {
+		return "", errors.New("object name is required")
+	}
 
 	result := ""
+	qualifiedName := name
+	if schemaName, objectName, err := ParseSchemaQualifiedName(name); err == nil {
+		qualifiedName = fmt.Sprintf("[%s].[%s]", schemaName, objectName)
+	}
 
 	query := "USE "
 	query += database
@@ -963,7 +1015,7 @@ func (db *MSSQL) GetObjectDefinition(database string, name string) (string, erro
     select @proc_source as result;
 	`
 
-	row := db.Connection.QueryRow(query, sql.Named("name", name))
+	row := db.Connection.QueryRow(query, sql.Named("name", qualifiedName))
 	if err := row.Scan(&result); err != nil {
 		return result, err
 	}

--- a/drivers/mssqql_test.go
+++ b/drivers/mssqql_test.go
@@ -1,6 +1,7 @@
 package drivers
 
 import (
+	"database/sql"
 	"fmt"
 	"reflect"
 	"testing"
@@ -17,6 +18,262 @@ const (
 	tableNameMSSQL = "test_table"
 	schemaMSSQL    = "dbo" // Explicit schema handling
 )
+
+func TestMSSQL_UseSchemas(t *testing.T) {
+	if !(&MSSQL{}).UseSchemas() {
+		t.Fatal("expected MSSQL to report schema support")
+	}
+}
+
+func TestMSSQL_GetTables_ReturnsSchemaQualifiedListings(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Fatalf("Error creating mock: %v", err)
+	}
+	defer db.Close()
+
+	mssql := &MSSQL{Connection: db}
+
+	rows := sqlmock.NewRows([]string{"schema_name", "table_name"}).
+		AddRow("dbo", "users").
+		AddRow("sales", "orders").
+		AddRow("sales", "users")
+
+	mock.ExpectQuery(`SELECT
+			s.name AS schema_name,
+			t.name AS table_name
+		FROM test_db.sys.tables t
+		INNER JOIN test_db.sys.schemas s
+			ON t.schema_id = s.schema_id
+		ORDER BY s.name, t.name`).WillReturnRows(rows)
+
+	tables, err := mssql.GetTables(DBNameMSSQL)
+	if err != nil {
+		t.Fatalf("GetTables failed: %v", err)
+	}
+
+	expected := map[string][]string{
+		"dbo":   {"users"},
+		"sales": {"orders", "users"},
+	}
+
+	if !reflect.DeepEqual(tables, expected) {
+		t.Fatalf("Expected %v, got %v", expected, tables)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("Unfulfilled expectations: %s", err)
+	}
+}
+
+func TestMSSQL_GetProgrammingObjects_ReturnQualifiedNames(t *testing.T) {
+	tests := []struct {
+		name     string
+		query    string
+		getter   func(*MSSQL, string) (map[string][]string, error)
+		expected []string
+	}{
+		{
+			name: "functions",
+			query: `USE test_db;
+		SELECT
+			s.name + '.' + o.name AS qualified_name
+		FROM sys.objects o
+		INNER JOIN sys.schemas s
+			ON o.schema_id = s.schema_id
+		WHERE o.type_desc IN ('SQL_SCALAR_FUNCTION', 'SQL_TABLE_VALUED_FUNCTION', 'SQL_INLINE_TABLE_VALUED_FUNCTION')
+		ORDER BY s.name, o.name`,
+			getter:   (*MSSQL).GetFunctions,
+			expected: []string{"dbo.monthly_sales", "sales.monthly_sales"},
+		},
+		{
+			name: "procedures",
+			query: `USE test_db;
+		SELECT
+			s.name + '.' + o.name AS qualified_name
+		FROM sys.objects o
+		INNER JOIN sys.schemas s
+			ON o.schema_id = s.schema_id
+		WHERE o.type_desc IN ('SQL_STORED_PROCEDURE')
+		ORDER BY s.name, o.name`,
+			getter:   (*MSSQL).GetProcedures,
+			expected: []string{"dbo.sync_customers", "sales.sync_customers"},
+		},
+		{
+			name: "views",
+			query: `USE test_db;
+		SELECT
+			s.name + '.' + o.name AS qualified_name
+		FROM sys.objects o
+		INNER JOIN sys.schemas s
+			ON o.schema_id = s.schema_id
+		WHERE o.type_desc IN ('VIEW')
+		ORDER BY s.name, o.name`,
+			getter:   (*MSSQL).GetViews,
+			expected: []string{"dbo.active_users", "sales.active_users"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+			if err != nil {
+				t.Fatalf("Error creating mock: %v", err)
+			}
+			defer db.Close()
+
+			mssql := &MSSQL{Connection: db}
+			rows := sqlmock.NewRows([]string{"qualified_name"})
+			for _, value := range tt.expected {
+				rows.AddRow(value)
+			}
+
+			mock.ExpectQuery(tt.query).WillReturnRows(rows)
+
+			objects, err := tt.getter(mssql, DBNameMSSQL)
+			if err != nil {
+				t.Fatalf("getter failed: %v", err)
+			}
+
+			expected := map[string][]string{DBNameMSSQL: tt.expected}
+			if !reflect.DeepEqual(objects, expected) {
+				t.Fatalf("Expected %v, got %v", expected, objects)
+			}
+
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Errorf("Unfulfilled expectations: %s", err)
+			}
+		})
+	}
+}
+
+func TestFormatSchemaQualifiedReference(t *testing.T) {
+	tests := []struct {
+		name      string
+		reference string
+		expected  string
+	}{
+		{name: "qualified", reference: "sales.orders", expected: "[sales].[orders]"},
+		{name: "unqualified", reference: "orders", expected: "[orders]"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatSchemaQualifiedReference(tt.reference); got != tt.expected {
+				t.Fatalf("expected %q, got %q", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestMSSQL_QualifiedLookupsUseBracketedSchemaReference(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("Error creating mock: %v", err)
+	}
+	defer db.Close()
+
+	mssql := &MSSQL{Connection: db}
+
+	recordRows := sqlmock.NewRows([]string{"id", "name"}).AddRow(1, "Alice")
+	mock.ExpectQuery("SELECT \\* FROM \\[sales\\]\\.\\[orders\\] ORDER BY \\(SELECT NULL\\) OFFSET \\@p1 ROWS FETCH NEXT \\@p2 ROWS ONLY").
+		WithArgs(0, DefaultRowLimit).
+		WillReturnRows(recordRows)
+	mock.ExpectQuery("SELECT COUNT\\(\\*\\) FROM \\[sales\\]\\.\\[orders\\]").
+		WillReturnRows(sqlmock.NewRows([]string{"count"}).AddRow(1))
+
+	if _, _, _, err := mssql.GetRecords(DBNameMSSQL, "sales.orders", "", "", 0, DefaultRowLimit); err != nil {
+		t.Fatalf("GetRecords failed: %v", err)
+	}
+
+	definitionRow := sqlmock.NewRows([]string{"result"}).AddRow("ALTER VIEW [sales].[active_users] AS SELECT 1")
+	mock.ExpectQuery("USE test_db; declare @proc_source nvarchar\\(max\\); select @proc_source = object_definition\\(object_id\\(@name\\)\\); if charindex\\('create', @proc_source\\) > 0 and charindex\\('create', @proc_source\\) < charindex\\(@name, @proc_source\\) begin set @proc_source = stuff\\(@proc_source, charindex\\('create', @proc_source\\), 6, 'alter'\\) end select @proc_source as result;").WithArgs(sql.Named("name", "[sales].[active_users]")).WillReturnRows(definitionRow)
+
+	definition, err := mssql.GetViewDefinition(DBNameMSSQL, "sales.active_users")
+	if err != nil {
+		t.Fatalf("GetViewDefinition failed: %v", err)
+	}
+
+	if definition != "ALTER VIEW [sales].[active_users] AS SELECT 1" {
+		t.Fatalf("unexpected definition: %s", definition)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("Unfulfilled expectations: %s", err)
+	}
+}
+
+func TestMSSQL_GetQualifiedTableMetadataAndPrimaryKeys(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Fatalf("Error creating mock: %v", err)
+	}
+	defer db.Close()
+
+	mssql := &MSSQL{Connection: db}
+
+	columnRows := sqlmock.NewRows([]string{"column_name", "data_type", "is_nullable", "column_default", "comment"}).
+		AddRow("id", "int", "0", "", "")
+
+	mock.ExpectQuery(`USE test_db;
+        SELECT
+            c.name AS column_name,
+            t.name AS data_type,
+            c.is_nullable,
+            def.definition AS column_default,
+            ISNULL(ep.value, '') AS comment
+        FROM sys.columns c
+        INNER JOIN sys.types t ON c.system_type_id = t.system_type_id
+        LEFT JOIN sys.default_constraints def ON c.default_object_id = def.parent_column_id
+        LEFT JOIN sys.extended_properties ep ON ep.major_id = c.object_id 
+            AND ep.minor_id = c.column_id 
+            AND ep.name = 'MS_Description'
+        WHERE c.object_id = OBJECT_ID(@p2)
+        AND t.name <> 'sysname'
+        ORDER BY c.column_id;
+    `).
+		WithArgs(DBNameMSSQL, "[sales].[orders]").
+		WillReturnRows(columnRows)
+
+	if _, err := mssql.GetTableColumns(DBNameMSSQL, "sales.orders"); err != nil {
+		t.Fatalf("GetTableColumns failed: %v", err)
+	}
+
+	pkRows := sqlmock.NewRows([]string{"column_name"}).AddRow("id")
+	mock.ExpectQuery(`USE test_db; SELECT
+			c.name AS column_name
+		FROM
+			sys.tables t
+		INNER JOIN
+			sys.schemas s
+				ON t.schema_id = s.schema_id
+		INNER JOIN
+			sys.key_constraints kc
+				ON t.object_id = kc.parent_object_id
+				AND kc.type = @p1
+		INNER JOIN
+			sys.index_columns ic
+				ON kc.unique_index_id = ic.index_id
+				AND t.object_id = ic.object_id
+		INNER JOIN
+			sys.columns c
+				ON ic.column_id = c.column_id
+				AND t.object_id = c.object_id
+		WHERE
+			s.name = @p2
+			AND t.name = @p3
+		ORDER BY ic.key_ordinal`).
+		WithArgs("PK", "sales", "orders").
+		WillReturnRows(pkRows)
+
+	if _, err := mssql.GetPrimaryKeyColumnNames(DBNameMSSQL, "sales.orders"); err != nil {
+		t.Fatalf("GetPrimaryKeyColumnNames failed: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("Unfulfilled expectations: %s", err)
+	}
+}
 
 func TestMSSQL_FormatArgForQueryString_SpecialCharacters(t *testing.T) {
 	db := &MSSQL{}
@@ -71,10 +328,6 @@ func TestMSSQL_GetPrimaryKeyColumnNames(t *testing.T) {
 	rows := sqlmock.NewRows([]string{"column_name"}).
 		AddRow("id")
 
-	schemaRow := sqlmock.NewRows([]string{"CurrentSchema"}).AddRow("dbo")
-
-	mock.ExpectQuery("SELECT SCHEMA_NAME() AS CurrentSchema").WillReturnRows(schemaRow)
-
 	// Match exact query structure with schema and USE prefix
 	mock.ExpectQuery(`USE test_db; SELECT
 			c.name AS column_name
@@ -102,7 +355,7 @@ func TestMSSQL_GetPrimaryKeyColumnNames(t *testing.T) {
 		WithArgs("PK", schemaMSSQL, tableNameMSSQL). // Use schema, not database name
 		WillReturnRows(rows)
 
-	keys, err := pg.GetPrimaryKeyColumnNames(DBNameMSSQL, tableNameMSSQL)
+	keys, err := pg.GetPrimaryKeyColumnNames(DBNameMSSQL, "dbo."+tableNameMSSQL)
 	if err != nil {
 		t.Fatalf("GetPrimaryKeyColumnNames failed: %v", err)
 	}
@@ -170,10 +423,11 @@ func TestMSSQL_GetForeignKeys(t *testing.T) {
         INNER JOIN sys.schemas s 
             ON t.schema_id = s.schema_id
         WHERE t.name = @p2
+          AND s.name = @p3
           AND DB_NAME(DB_ID(@p1)) = @p1
-    `).WithArgs(DBNameMSSQL, tableNameMSSQL).WillReturnRows(rows)
+    `).WithArgs(DBNameMSSQL, tableNameMSSQL, schemaMSSQL).WillReturnRows(rows)
 
-	constraints, err := pg.GetForeignKeys(DBNameMSSQL, tableNameMSSQL)
+	constraints, err := pg.GetForeignKeys(DBNameMSSQL, "dbo."+tableNameMSSQL)
 	if err != nil {
 		t.Fatalf("GetForeignKeys failed: %v", err)
 	}
@@ -289,10 +543,6 @@ func TestMSSQL_GetIndexes(t *testing.T) {
 		"name",
 	)
 
-	schemaRow := sqlmock.NewRows([]string{"CurrentSchema"}).AddRow("dbo")
-
-	mock.ExpectQuery("SELECT SCHEMA_NAME() AS CurrentSchema").WillReturnRows(schemaRow)
-
 	mock.ExpectQuery(`
         USE test_db; SELECT
             t.name AS table_name,
@@ -326,7 +576,7 @@ func TestMSSQL_GetIndexes(t *testing.T) {
 		WithArgs(DBNameMSSQL, tableNameMSSQL, schemaMSSQL).
 		WillReturnRows(rows)
 
-	indexes, err := pg.GetIndexes(DBNameMSSQL, tableNameMSSQL)
+	indexes, err := pg.GetIndexes(DBNameMSSQL, "dbo."+tableNameMSSQL)
 	if err != nil {
 		t.Fatalf("GetIndexes failed: %v", err)
 	}

--- a/drivers/utils.go
+++ b/drivers/utils.go
@@ -34,6 +34,27 @@ func queriesInTransaction(db *sql.DB, queries []models.Query) (err error) {
 	return nil
 }
 
+func ParseSchemaQualifiedName(name string) (string, string, error) {
+	if name == "" {
+		return "", "", fmt.Errorf("object name is required")
+	}
+
+	parts := strings.SplitN(name, ".", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf("object name must be in format schema.name")
+	}
+
+	return parts[0], parts[1], nil
+}
+
+func BuildSchemaQualifiedName(schema string, name string) string {
+	if schema == "" {
+		return name
+	}
+
+	return schema + "." + name
+}
+
 func buildInsertQueryString(formattedTableName string, columns []string, values []any, driver Driver) string {
 	sanitizedValues := make([]string, len(values))
 

--- a/drivers/utils_test.go
+++ b/drivers/utils_test.go
@@ -72,6 +72,46 @@ func (m *mockDriver) FormatPlaceholder(index int) string {
 	return fmt.Sprintf("$%d", index)
 }
 
+func TestParseSchemaQualifiedName(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		schema    string
+		object    string
+		wantError bool
+	}{
+		{name: "qualified", input: "sales.orders", schema: "sales", object: "orders"},
+		{name: "missing schema", input: "orders", wantError: true},
+		{name: "missing object", input: "sales.", wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			schema, object, err := ParseSchemaQualifiedName(tt.input)
+			if tt.wantError {
+				if err == nil {
+					t.Fatalf("expected error for %q", tt.input)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tt.input, err)
+			}
+
+			if schema != tt.schema || object != tt.object {
+				t.Fatalf("expected (%q,%q), got (%q,%q)", tt.schema, tt.object, schema, object)
+			}
+		})
+	}
+}
+
+func TestBuildSchemaQualifiedName(t *testing.T) {
+	if got := BuildSchemaQualifiedName("sales", "orders"); got != "sales.orders" {
+		t.Fatalf("expected sales.orders, got %q", got)
+	}
+}
+
 func Test_queriesInTransaction(t *testing.T) {
 	tests := []struct {
 		setMockExpectations func(mock gomock.Sqlmock)


### PR DESCRIPTION
Closes #245

## Summary
- fix MSSQL multi-schema object resolution
- show MSSQL tree items as `Schema.ObjectName` in existing categories
- avoid ambiguity when duplicate object names exist across schemas

## Changes
- add schema-qualified MSSQL lookups for tables, functions, procedures, and views
- add shared qualified-name helpers in the driver layer
- update tree rendering/tests for qualified MSSQL item labels
