### PR TITLE
fix: quit dialog becomes unresponsive when opened during table load

### DIFF
--- a/components/home.go
+++ b/components/home.go
@@ -213,7 +213,10 @@ func (home *Home) showTable(databaseName, tableName string) {
 	}
 
 	table.FetchRecords(func() {
-		home.focusLeftWrapper()
+		if !quitConfirmationVisible() {
+			home.focusLeftWrapper()
+		}
+		keepQuitConfirmationFocused()
 	}, func() {
 		if !app.App.Config().DisableSidebar && !table.GetShowSidebar() {
 			records := table.GetRecords()
@@ -223,15 +226,28 @@ func (home *Home) showTable(databaseName, tableName string) {
 		}
 
 		if table.state.error == "" {
-			if !home.treePinned && home.leftWrapperVisible {
+			// toggleLeftWrapper moves focus to the table; skip it while the quit
+			// dialog is up so a load finishing after 'q' can't steal focus from
+			// the dialog and leave it undismissable.
+			if !home.treePinned && home.leftWrapperVisible && !quitConfirmationVisible() {
 				home.toggleLeftWrapper()
 			}
 		}
 
 		App.ForceDraw()
+		keepQuitConfirmationFocused()
 	})
 
-	home.focusRightWrapper()
+	// showTable runs on the tree-subscription goroutine, so a bare focus call
+	// here races with a 'q' pressed while the table is opening. Marshal it onto
+	// the UI loop so the "is the quit dialog up?" check is atomic with the
+	// dialog being shown; if it is up, leave focus on it so it stays dismissable.
+	App.QueueUpdateDraw(func() {
+		if !quitConfirmationVisible() {
+			home.focusRightWrapper()
+		}
+		keepQuitConfirmationFocused()
+	})
 }
 
 func (home *Home) ShowTableWithFilter(databaseName, tableName, where string) {
@@ -258,10 +274,14 @@ func (home *Home) ShowTableWithFilter(databaseName, tableName, where string) {
 	}
 
 	table.FetchRecords(func() {
-		home.focusLeftWrapper()
+		if !quitConfirmationVisible() {
+			home.focusLeftWrapper()
+		}
+		keepQuitConfirmationFocused()
 	}, func() {
 		if table.state.error != "" {
 			App.ForceDraw()
+			keepQuitConfirmationFocused()
 			return
 		}
 
@@ -272,13 +292,19 @@ func (home *Home) ShowTableWithFilter(databaseName, tableName, where string) {
 			}
 		}
 
-		if !home.treePinned && home.leftWrapperVisible {
+		if !home.treePinned && home.leftWrapperVisible && !quitConfirmationVisible() {
 			home.toggleLeftWrapper()
 		}
 		App.ForceDraw()
+		keepQuitConfirmationFocused()
 	})
 
-	home.focusRightWrapper()
+	// See showTable: this runs on the tree-subscription goroutine and races
+	// with a 'q' pressed while the table is opening.
+	if !quitConfirmationVisible() {
+		home.focusRightWrapper()
+	}
+	keepQuitConfirmationFocused()
 }
 
 func (home *Home) focusRightWrapper() {

--- a/components/pages.go
+++ b/components/pages.go
@@ -6,7 +6,12 @@ import (
 	"github.com/jorgerojas26/lazysql/app"
 )
 
-var mainPages *tview.Pages
+var (
+	mainPages *tview.Pages
+	// quitConfirmationModal holds the currently visible quit dialog, if any, so
+	// its focus can be re-asserted after an async callback steals it.
+	quitConfirmationModal *ConfirmationModal
+)
 
 func showQuitConfirmation() {
 	if !app.App.Config().ConfirmOnQuit {
@@ -19,12 +24,20 @@ func showQuitConfirmation() {
 	}
 
 	if mainPages.HasPage(pageNameConfirmation) {
+		// The dialog is already up. A background task (e.g. a table finishing
+		// loading) may have stolen focus from it, leaving it undismissable, so
+		// re-assert focus instead of silently doing nothing.
+		if quitConfirmationModal != nil {
+			app.App.SetFocus(quitConfirmationModal)
+		}
 		return
 	}
 
 	confirmationModal := NewConfirmationModal("Exit LazySQL?")
+	quitConfirmationModal = confirmationModal
 	confirmationModal.SetDoneFunc(func(_ int, buttonLabel string) {
 		mainPages.RemovePage(pageNameConfirmation)
+		quitConfirmationModal = nil
 		if buttonLabel == confirmationYes {
 			app.App.Stop()
 		}
@@ -36,6 +49,23 @@ func showQuitConfirmation() {
 func closeQuitConfirmation() {
 	if mainPages != nil {
 		mainPages.RemovePage(pageNameConfirmation)
+	}
+	quitConfirmationModal = nil
+}
+
+// quitConfirmationVisible reports whether the quit dialog is currently shown.
+// Async completion callbacks use it to avoid moving focus away from the dialog.
+func quitConfirmationVisible() bool {
+	return mainPages != nil && mainPages.HasPage(pageNameConfirmation)
+}
+
+// keepQuitConfirmationFocused re-asserts focus on the quit dialog when it is
+// visible. Async completion callbacks that call SetFocus (table loads, filter
+// changes, etc.) must call this last so they cannot strand the modal on-screen
+// but unfocused, which would make it impossible to dismiss.
+func keepQuitConfirmationFocused() {
+	if quitConfirmationVisible() && quitConfirmationModal != nil {
+		app.App.SetFocus(quitConfirmationModal)
 	}
 }
 


### PR DESCRIPTION
Pressing 'q' while a results table is still loading could leave the "Exit LazySQL?" dialog on screen but completely unresponsive — no button, arrow key, Enter, or even Ctrl+C would work, forcing the pane to be killed.

Root cause is a focus-theft race, not a deadlock. showQuitConfirmation() shows the modal and focuses it, but the in-flight table load then completes and its focus calls (focusRightWrapper / toggleLeftWrapper / focusLeftWrapper, some run from the tree-subscription goroutine) call SetFocus on the table or tree, stealing focus from the modal. The modal stays drawn but unfocused, so keystrokes go to the widget behind it. Because showQuitConfirmation() and the Ctrl+C handler both short-circuit on HasPage(pageNameConfirmation), 'q' and Ctrl+C then become no-ops too — total lockout.

Fix:
- Track the live quit modal and re-assert its focus on repeat 'q'/Ctrl+C instead of silently returning, so it can never be stranded unfocused.
- Skip the load-completion focus changes while the quit dialog is visible.
- Marshal showTable's focus call onto the UI loop via QueueUpdateDraw so the "is the dialog up?" check is atomic with the dialog being shown, closing the cross-goroutine race.

Verified with a scripted tmux stress harness: previously ~15-20% of "open table + immediately quit" runs hung; 0 hangs across 160 runs after the fix. Normal navigation and clean quit are unchanged; go vet, gofmt, and the components/app/drivers tests all pass.

Fixes #325 