### PR TITLE
fix: sidebar showing wrong fields

### DIFF
--- a/components/results_table.go
+++ b/components/results_table.go
@@ -2048,9 +2048,15 @@ func (table *ResultsTable) UpdateSidebar() {
 
 		table.Sidebar.Clear()
 
-		for i := 1; i < len(columns); i++ {
-			name := columns[i][0]
-			colType := columns[i][1]
+		isRecordsTab := table.Menu == nil || table.Menu.GetSelectedOption() == 1
+
+		for i := 1; i <= table.GetColumnCount(); i++ {
+			name := table.GetCell(0, i-1).Text
+
+			colType := ""
+			if isRecordsTab && i < len(columns) {
+				colType = columns[i][1]
+			}
 
 			sidebarWidth := table.getSidebarWidth()
 


### PR DESCRIPTION
### Fix: sidebar shows wrong labels on non Records tabs (Columns, Constraints, FKs, Indexes)

closes https://github.com/jorgerojas26/lazysql/issues/323
  
**Bug:** 
 On any tab other than Records, the sidebar's field labels didn't match their values, titles came from column state (set once at table open) while values came from the currently displayed grid, so they were reading from two unrelated sources. 

  **Fix:** 
 - `UpdateSidebar()` now reads titles directly from the active grid's own header row instead of the frozen column state grid, and loops over the grid's actual column count instead of the DB column count.
 - Also stop showing 'colType' suffix on non record tabs
 
Verified with a real db connection

  