### PR TITLE
feat: support cross-database query execution in SQL editor (MSSQL, MySQL, PostgreSQL)

### DIFF
--- a/components/results_table.go
+++ b/components/results_table.go
@@ -859,7 +859,7 @@ func (table *ResultsTable) subscribeToEditorChanges() {
 							return
 						}
 
-						rows, records, err := table.DBDriver.ExecuteQuery(query)
+						rows, records, err := table.DBDriver.ExecuteQuery(table.GetDatabaseName(), query)
 
 						if ctx.Err() != nil {
 							return

--- a/components/tree_test.go
+++ b/components/tree_test.go
@@ -372,9 +372,11 @@ func (m *schemaProgrammingMock) UpdateRecord(string, string, string, string, str
 }
 func (m *schemaProgrammingMock) DeleteRecord(string, string, string, string) error { return nil }
 func (m *schemaProgrammingMock) ExecuteDMLStatement(string) (string, error)        { return "", nil }
-func (m *schemaProgrammingMock) ExecuteQuery(string) ([][]string, int, error)      { return nil, 0, nil }
-func (m *schemaProgrammingMock) ExecutePendingChanges([]models.DBDMLChange) error  { return nil }
-func (m *schemaProgrammingMock) GetProvider() string                               { return "mock" }
+func (m *schemaProgrammingMock) ExecuteQuery(string, string) ([][]string, int, error) {
+	return nil, 0, nil
+}
+func (m *schemaProgrammingMock) ExecutePendingChanges([]models.DBDMLChange) error { return nil }
+func (m *schemaProgrammingMock) GetProvider() string                              { return "mock" }
 func (m *schemaProgrammingMock) GetPrimaryKeyColumnNames(string, string) ([]string, error) {
 	return nil, nil
 }

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -17,7 +17,12 @@ type Driver interface {
 	UpdateRecord(database, table, column, value, primaryKeyColumnName, primaryKeyValue string) error
 	DeleteRecord(database, table string, primaryKeyColumnName, primaryKeyValue string) error
 	ExecuteDMLStatement(query string) (string, error)
-	ExecuteQuery(query string) ([][]string, int, error)
+	// database selects which database the query runs against. Drivers that
+	// support switching database context within a single connection (MSSQL,
+	// MySQL) prefix the query accordingly; drivers that require a dedicated
+	// connection per database (PostgreSQL) route the query through it.
+	// An empty database falls back to the connection's current database.
+	ExecuteQuery(database, query string) ([][]string, int, error)
 	ExecutePendingChanges(changes []models.DBDMLChange) error
 	GetProvider() string
 	GetPrimaryKeyColumnNames(database, table string) ([]string, error)

--- a/drivers/mssqql.go
+++ b/drivers/mssqql.go
@@ -19,8 +19,9 @@ import (
 )
 
 type MSSQL struct {
-	Connection *sql.DB
-	Provider   string
+	Connection      *sql.DB
+	Provider        string
+	CurrentDatabase string
 }
 
 // mssqlGUIDToUUID converts a 16-byte little-endian GUID from MSSQL
@@ -73,6 +74,18 @@ func (db *MSSQL) Connect(urlstr string) error {
 	if err := db.Connection.Ping(); err != nil {
 		return err
 	}
+
+	// Track the database in scope at connection time so ExecuteQuery can
+	// avoid an unnecessary "USE" statement when the caller targets the same
+	// database the connection is already on.
+	row := db.Connection.QueryRow("SELECT DB_NAME()")
+
+	var database string
+	if err := row.Scan(&database); err != nil {
+		return err
+	}
+
+	db.CurrentDatabase = database
 
 	return nil
 }
@@ -487,12 +500,17 @@ func (db *MSSQL) ExecuteDMLStatement(query string) (string, error) {
 	return fmt.Sprintf("%d rows affected", rowsAffected), nil
 }
 
-func (db *MSSQL) ExecuteQuery(query string) ([][]string, int, error) {
+func (db *MSSQL) ExecuteQuery(database, query string) ([][]string, int, error) {
 	if query == "" {
 		return nil, 0, errors.New("query can not be empty")
 	}
 
-	rows, err := db.Connection.Query(query)
+	executableQuery := query
+	if database != "" && database != db.CurrentDatabase {
+		executableQuery = fmt.Sprintf("USE %s; %s", database, query)
+	}
+
+	rows, err := db.Connection.Query(executableQuery)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/drivers/mssqql_test.go
+++ b/drivers/mssqql_test.go
@@ -511,3 +511,64 @@ func TestMSSQL_GetRecords(t *testing.T) {
 		t.Errorf("Unfulfilled expectations: %s", err)
 	}
 }
+
+func TestMSSQL_ExecuteQuery_CrossDatabase(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Fatalf("Error creating mock: %v", err)
+	}
+	defer db.Close()
+
+	mssql := &MSSQL{Connection: db, CurrentDatabase: "otherdb"}
+
+	rows := sqlmock.NewRows([]string{"id", "name"}).AddRow(1, "Alice")
+
+	mock.ExpectQuery("USE targetdb; SELECT * FROM users").WillReturnRows(rows)
+
+	results, total, err := mssql.ExecuteQuery("targetdb", "SELECT * FROM users")
+	if err != nil {
+		t.Fatalf("ExecuteQuery failed: %v", err)
+	}
+
+	if total != 1 {
+		t.Fatalf("Expected total 1, got %d", total)
+	}
+
+	expected := [][]string{
+		{"id", "name"},
+		{"1", "Alice"},
+	}
+
+	if !reflect.DeepEqual(results, expected) {
+		t.Fatalf("Expected %v, got %v", expected, results)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("Unfulfilled expectations: %s", err)
+	}
+}
+
+func TestMSSQL_ExecuteQuery_SameDatabase_NoUseStatement(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
+	if err != nil {
+		t.Fatalf("Error creating mock: %v", err)
+	}
+	defer db.Close()
+
+	mssql := &MSSQL{Connection: db, CurrentDatabase: "targetdb"}
+
+	rows := sqlmock.NewRows([]string{"id"}).AddRow(1)
+
+	// Exact-match query matcher: if a USE prefix leaked in, this expectation
+	// would fail to match and the test would fail.
+	mock.ExpectQuery("SELECT * FROM users").WillReturnRows(rows)
+
+	_, _, err = mssql.ExecuteQuery("targetdb", "SELECT * FROM users")
+	if err != nil {
+		t.Fatalf("ExecuteQuery failed: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("Unfulfilled expectations: %s", err)
+	}
+}

--- a/drivers/mysql.go
+++ b/drivers/mysql.go
@@ -1,6 +1,7 @@
 package drivers
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -13,8 +14,9 @@ import (
 )
 
 type MySQL struct {
-	Connection *sql.DB
-	Provider   string
+	Connection      *sql.DB
+	Provider        string
+	CurrentDatabase string
 }
 
 func (db *MySQL) TestConnection(urlstr string) (err error) {
@@ -33,6 +35,18 @@ func (db *MySQL) Connect(urlstr string) (err error) {
 	if err != nil {
 		return err
 	}
+
+	// Track the database in scope at connection time so ExecuteQuery can
+	// avoid an unnecessary "USE" statement when the caller targets the same
+	// database the connection is already on.
+	row := db.Connection.QueryRow("SELECT DATABASE()")
+
+	var database sql.NullString
+	if err := row.Scan(&database); err != nil {
+		return err
+	}
+
+	db.CurrentDatabase = database.String
 
 	return nil
 }
@@ -384,13 +398,46 @@ func (db *MySQL) GetRecords(database, table, where, sort string, offset, limit i
 	return paginatedResults, totalRecords, queryString, nil
 }
 
-func (db *MySQL) ExecuteQuery(query string) ([][]string, int, error) {
+func (db *MySQL) ExecuteQuery(database, query string) ([][]string, int, error) {
+	// The MySQL driver does not support multiple statements in a single
+	// Query call by default (no multiStatements=true in the DSN), so "USE"
+	// and the actual query must run sequentially on the *same* pooled
+	// connection to avoid the USE landing on a different physical
+	// connection than the query.
+	if database != "" && database != db.CurrentDatabase {
+		ctx := context.Background()
+
+		conn, err := db.Connection.Conn(ctx)
+		if err != nil {
+			return nil, 0, err
+		}
+		defer conn.Close()
+
+		if _, err := conn.ExecContext(ctx, fmt.Sprintf("USE `%s`", database)); err != nil {
+			return nil, 0, err
+		}
+
+		rows, err := conn.QueryContext(ctx, query)
+		if err != nil {
+			return nil, 0, err
+		}
+		defer rows.Close()
+
+		return scanMySQLRows(rows)
+	}
+
 	rows, err := db.Connection.Query(query)
 	if err != nil {
 		return nil, 0, err
 	}
 	defer rows.Close()
 
+	return scanMySQLRows(rows)
+}
+
+// scanMySQLRows scans a *sql.Rows into the [][]string shape used across the
+// codebase, with the column names prepended as the first row.
+func scanMySQLRows(rows *sql.Rows) ([][]string, int, error) {
 	columns, err := rows.Columns()
 	if err != nil {
 		return nil, 0, err
@@ -403,8 +450,7 @@ func (db *MySQL) ExecuteQuery(query string) ([][]string, int, error) {
 			rowValues[i] = new(sql.RawBytes)
 		}
 
-		err = rows.Scan(rowValues...)
-		if err != nil {
+		if err := rows.Scan(rowValues...); err != nil {
 			return nil, 0, err
 		}
 

--- a/drivers/mysql_test.go
+++ b/drivers/mysql_test.go
@@ -844,7 +844,7 @@ func TestMySQL_ExecuteQuery_Error(t *testing.T) {
 
 	mock.ExpectQuery(fmt.Sprintf("SELECT \\* FROM %s", mysql.formatTableName(testDBNameMySQL, testDBTableNameMySQL))).WillReturnError(errors.New("query error"))
 
-	_, _, err = mysql.ExecuteQuery(fmt.Sprintf("SELECT * FROM %s", mysql.formatTableName(testDBNameMySQL, testDBTableNameMySQL)))
+	_, _, err = mysql.ExecuteQuery("", fmt.Sprintf("SELECT * FROM %s", mysql.formatTableName(testDBNameMySQL, testDBTableNameMySQL)))
 
 	if err == nil {
 		t.Fatalf("Expected error, but got nil")
@@ -1439,7 +1439,7 @@ func TestMySQL_ExecuteQuery(t *testing.T) {
 	mock.ExpectQuery(fmt.Sprintf("SELECT \\* FROM %s", mysql.formatTableName(testDBNameMySQL, testDBTableNameMySQL))).
 		WillReturnRows(rows)
 
-	results, _, err := mysql.ExecuteQuery(fmt.Sprintf("SELECT * FROM %s", mysql.formatTableName(testDBNameMySQL, testDBTableNameMySQL)))
+	results, _, err := mysql.ExecuteQuery("", fmt.Sprintf("SELECT * FROM %s", mysql.formatTableName(testDBNameMySQL, testDBTableNameMySQL)))
 	if err != nil {
 		t.Fatalf("ExecuteQuery failed: %v", err)
 	}
@@ -1452,6 +1452,69 @@ func TestMySQL_ExecuteQuery(t *testing.T) {
 
 	if !reflect.DeepEqual(results, expectedResults) {
 		t.Fatalf("Expected results:\n%v\nGot:\n%v", expectedResults, results)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %s", err)
+	}
+}
+
+func TestMySQL_ExecuteQuery_CrossDatabase(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("error creating mock: %s", err)
+	}
+	defer db.Close()
+
+	mysql := &MySQL{Connection: db, CurrentDatabase: "otherdb"}
+
+	columns := []string{"id", "name"}
+	rows := sqlmock.NewRows(columns).AddRow(1, "Alice")
+
+	mock.ExpectExec("USE `targetdb`").WillReturnResult(sqlmock.NewResult(0, 0))
+	mock.ExpectQuery("SELECT \\* FROM users").WillReturnRows(rows)
+
+	results, total, err := mysql.ExecuteQuery("targetdb", "SELECT * FROM users")
+	if err != nil {
+		t.Fatalf("ExecuteQuery failed: %v", err)
+	}
+
+	if total != 1 {
+		t.Fatalf("Expected total 1, got %d", total)
+	}
+
+	expectedResults := [][]string{
+		{"id", "name"},
+		{"1", "Alice"},
+	}
+
+	if !reflect.DeepEqual(results, expectedResults) {
+		t.Fatalf("Expected results:\n%v\nGot:\n%v", expectedResults, results)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("unfulfilled expectations: %s", err)
+	}
+}
+
+func TestMySQL_ExecuteQuery_SameDatabase_NoUseStatement(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("error creating mock: %s", err)
+	}
+	defer db.Close()
+
+	mysql := &MySQL{Connection: db, CurrentDatabase: "targetdb"}
+
+	columns := []string{"id"}
+	rows := sqlmock.NewRows(columns).AddRow(1)
+
+	// No ExpectExec for USE: only the SELECT should be issued.
+	mock.ExpectQuery("SELECT \\* FROM users").WillReturnRows(rows)
+
+	_, _, err = mysql.ExecuteQuery("targetdb", "SELECT * FROM users")
+	if err != nil {
+		t.Fatalf("ExecuteQuery failed: %v", err)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {

--- a/drivers/postgres.go
+++ b/drivers/postgres.go
@@ -620,8 +620,23 @@ func (db *Postgres) ExecuteDMLStatement(query string) (result string, err error)
 	return fmt.Sprintf("%d rows affected", rowsAffected), nil
 }
 
-func (db *Postgres) ExecuteQuery(query string) ([][]string, int, error) {
-	rows, err := db.Connection.Query(query)
+func (db *Postgres) ExecuteQuery(database, query string) ([][]string, int, error) {
+	// An empty database falls back to whatever the connection is currently
+	// on (preserves pre-existing behavior for callers that don't resolve a
+	// database name).
+	if database == "" {
+		database = db.CurrentDatabase
+	}
+
+	conn, needsClose, err := db.connectionFor(database)
+	if err != nil {
+		return nil, 0, err
+	}
+	if needsClose {
+		defer conn.Close()
+	}
+
+	rows, err := conn.Query(query)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/drivers/postgres_test.go
+++ b/drivers/postgres_test.go
@@ -360,6 +360,69 @@ func TestPostgres_GetRecords(t *testing.T) {
 	}
 }
 
+func TestPostgres_ExecuteQuery_SameDatabase(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("Error creating mock: %v", err)
+	}
+	defer db.Close()
+
+	// connectionFor short-circuits to the existing connection when the
+	// requested database matches CurrentDatabase, so no new physical
+	// connection (untestable via sqlmock) is opened.
+	pg := &Postgres{Connection: db, CurrentDatabase: DBNamePostgres}
+
+	rows := sqlmock.NewRows([]string{"id", "name"}).AddRow(1, "Alice")
+
+	mock.ExpectQuery(`SELECT \* FROM users`).WillReturnRows(rows)
+
+	results, total, err := pg.ExecuteQuery(DBNamePostgres, "SELECT * FROM users")
+	if err != nil {
+		t.Fatalf("ExecuteQuery failed: %v", err)
+	}
+
+	if total != 1 {
+		t.Fatalf("Expected total 1, got %d", total)
+	}
+
+	expected := [][]string{
+		{"id", "name"},
+		{"1", "Alice"},
+	}
+
+	if !reflect.DeepEqual(results, expected) {
+		t.Fatalf("Expected %v, got %v", expected, results)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("Unfulfilled expectations: %s", err)
+	}
+}
+
+func TestPostgres_ExecuteQuery_EmptyDatabaseFallsBackToCurrent(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatalf("Error creating mock: %v", err)
+	}
+	defer db.Close()
+
+	pg := &Postgres{Connection: db, CurrentDatabase: DBNamePostgres}
+
+	rows := sqlmock.NewRows([]string{"id"}).AddRow(1)
+
+	mock.ExpectQuery(`SELECT \* FROM users`).WillReturnRows(rows)
+
+	// Empty database string must not attempt to open a new connection to "".
+	_, _, err = pg.ExecuteQuery("", "SELECT * FROM users")
+	if err != nil {
+		t.Fatalf("ExecuteQuery failed: %v", err)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("Unfulfilled expectations: %s", err)
+	}
+}
+
 func TestPostgres_GetForeignKeys(t *testing.T) {
 	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual))
 	if err != nil {

--- a/drivers/sqlite.go
+++ b/drivers/sqlite.go
@@ -374,7 +374,9 @@ func (db *SQLite) GetRecords(_, table, where, sort string, offset, limit int) (p
 	return paginatedResults, totalRecords, queryString, nil
 }
 
-func (db *SQLite) ExecuteQuery(query string) ([][]string, int, error) {
+// ExecuteQuery ignores the database parameter: SQLite is a single-file
+// database with no concept of multiple databases within one connection.
+func (db *SQLite) ExecuteQuery(_, query string) ([][]string, int, error) {
 	rows, err := db.Connection.Query(query)
 	if err != nil {
 		return nil, 0, err

--- a/drivers/utils_test.go
+++ b/drivers/utils_test.go
@@ -30,11 +30,11 @@ func (m *mockDriver) GetRecords(string, string, string, string, int, int) ([][]s
 func (m *mockDriver) UpdateRecord(string, string, string, string, string, string) error {
 	panic("not used")
 }
-func (m *mockDriver) DeleteRecord(string, string, string, string) error { panic("not used") }
-func (m *mockDriver) ExecuteDMLStatement(string) (string, error)        { panic("not used") }
-func (m *mockDriver) ExecuteQuery(string) ([][]string, int, error)      { panic("not used") }
-func (m *mockDriver) ExecutePendingChanges([]models.DBDMLChange) error  { panic("not used") }
-func (m *mockDriver) GetProvider() string                               { return "mock" }
+func (m *mockDriver) DeleteRecord(string, string, string, string) error    { panic("not used") }
+func (m *mockDriver) ExecuteDMLStatement(string) (string, error)           { panic("not used") }
+func (m *mockDriver) ExecuteQuery(string, string) ([][]string, int, error) { panic("not used") }
+func (m *mockDriver) ExecutePendingChanges([]models.DBDMLChange) error     { panic("not used") }
+func (m *mockDriver) GetProvider() string                                  { return "mock" }
 func (m *mockDriver) GetPrimaryKeyColumnNames(string, string) ([]string, error) {
 	panic("not used")
 }


### PR DESCRIPTION
## What

Cross-database query execution in the SQL editor for MSSQL, MySQL and PostgreSQL.

The tree already lets you browse every database in an instance (`GetTables`,
`GetRecords`, etc. all take a `database` parameter), but the free-form SQL
editor (`ExecuteQuery`) always ran against whatever database the connection
was originally opened on, regardless of which database node was selected in
the tree. This closes that gap.

## Why

Working across multiple databases on the same MSSQL/Postgres instance is a
common workflow (e.g. ad-hoc cross-schema/cross-catalog queries, comparing
data between environments living on the same server). Today the only way to
query a different database in the editor is to reconnect entirely.

## How

- `Driver.ExecuteQuery` now takes a `database` parameter.
- **MSSQL**: prefixes the query with `USE [database];` when it differs from
  the connection's current database — the same pattern already used by
  `GetRecords`. Adds `CurrentDatabase` tracking (via `DB_NAME()`) on
  `Connect` so the prefix is only emitted when actually switching.
- **MySQL**: issues `USE `database`` as a separate statement on a reserved
  `*sql.Conn` before running the query. This is necessary because the MySQL
  driver doesn't enable `multiStatements` in the DSN, so a single batched
  `USE ...; SELECT ...` isn't supported the way it is for MSSQL. Adds
  `CurrentDatabase` tracking (via `DATABASE()`) on `Connect`.
- **PostgreSQL**: reuses the existing `connectionFor` helper (previously
  implemented for `GetRecords` but otherwise unused), which transparently
  opens a short-lived connection to the target database when it differs
  from the current one. Postgres has no in-session `USE`, so a separate
  connection is the only option.
- **SQLite**: parameter accepted but ignored — single-file database, no
  multi-database concept.
- `components/results_table.go` now passes the tree-selected database name
  through to `ExecuteQuery`, matching how it's already threaded through
  `GetRecords`.

## Testing

- Added unit tests covering both the same-database (no `USE`/extra
  connection) and cross-database (`USE` emitted / alternate connection
  used) paths for MSSQL, MySQL and PostgreSQL.
- `go build ./...`, `go vet ./...`, `go test ./...` all pass.
- `gofmt -l .` clean.

## Risks / rollback

- Interface change to `Driver.ExecuteQuery` touches all four drivers and
  their test mocks — kept exhaustive to avoid silent gaps.
- MySQL's `USE` is issued on a dedicated `sql.Conn` (not the shared pool)
  specifically to avoid a `USE` landing on a different physical connection
  than the subsequent query.
- Postgres opens a short-lived extra connection only when switching
  databases; same trade-off already accepted by the existing `GetRecords`
  implementation.
- Straightforward revert: this is additive/backwards-compatible in behavior
  (empty database string preserves prior behavior for all drivers).
