### PR TITLE
feat: add "show all databases" option to the connection form

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,18 @@ EnterOpensJSONViewer = false
 
 The `ReadOnly` field (optional, defaults to `false`) can be set to `true` to enable read-only mode for a connection. When enabled, all mutation queries (INSERT, UPDATE, DELETE, DROP, etc.) will be blocked.
 
+The `DBName` field (optional) controls how the sidebar tree is populated when a connection is opened:
+
+- **`DBName` set** (e.g. `DBName = 'foo'`): the tree is pinned to that single database only. This is the default behavior when a connection is created/edited through the in-app connection form, since `DBName` is auto-filled from whatever database is embedded in the connection URL.
+- **`DBName` empty or omitted**: the tree lists *every* database in the instance that the connecting user has `CONNECT` privileges on (via `GetDatabases()`), not just the one in the URL. This is useful when you regularly need to browse or query across multiple databases/catalogs on the same PostgreSQL or MSSQL server — PostgreSQL in particular requires a database to be specified in the connection string even though the same login is often valid for several databases on that instance.
+
+To enable multi-database browsing for a connection, either:
+
+- Remove/comment out the `DBName` line for that connection directly in `config.toml`, **or**
+- Check **"Show all databases in this instance"** when adding or editing the connection through the in-app connection form (`a` to add, `e` to edit from the connection picker). This overrides the auto-filled `DBName` and saves the connection with it left empty, without you needing to hand-edit the TOML file. When re-opening an existing connection for editing, the checkbox is automatically pre-checked if it was previously saved this way.
+
+Note: this setting only affects which databases populate the sidebar tree. It does not change which database the initial connection is authenticated against — that is still determined entirely by the database in the connection URL (a requirement of the PostgreSQL and MSSQL wire protocols).
+
 The `[application]` section is used to define some app settings. Not all settings are available yet, this is a work in progress.
 
 ### Application settings

--- a/components/connection_form.go
+++ b/components/connection_form.go
@@ -28,6 +28,7 @@ func NewConnectionForm(connectionPages *models.ConnectionPages) *ConnectionForm 
 	addForm.AddInputField("Name", "", 0, nil, nil)
 	addForm.AddInputField("URL", "", 0, nil, nil)
 	addForm.AddCheckbox("Read-Only", false, nil)
+	addForm.AddCheckbox("Show all databases in this instance", false, nil)
 
 	buttonsWrapper := tview.NewFlex().SetDirection(tview.FlexColumn)
 
@@ -99,13 +100,21 @@ func (form *ConnectionForm) inputCapture(connectionPages *models.ConnectionPages
 			databases := app.App.Connections()
 			newDatabases := make([]models.Connection, len(databases))
 
-			DBName := strings.Split(parsed.Normalize(",", "NULL", 0), ",")[3]
-
-			if DBName == "NULL" {
-				DBName = ""
-			}
-
 			readOnly := form.GetFormItem(2).(*tview.Checkbox).IsChecked()
+			showAllDatabases := form.GetFormItem(3).(*tview.Checkbox).IsChecked()
+
+			// When the user opts in to browsing every database in the
+			// instance, force DBName empty so the tree's InitializeNodes
+			// falls back to GetDatabases() instead of pinning to whatever
+			// database happens to be embedded in the connection URL.
+			var DBName string
+			if !showAllDatabases {
+				DBName = strings.Split(parsed.Normalize(",", "NULL", 0), ",")[3]
+
+				if DBName == "NULL" {
+					DBName = ""
+				}
+			}
 
 			parsedDatabaseData := models.Connection{
 				Name:     connectionName,
@@ -205,4 +214,26 @@ func (form *ConnectionForm) SetConnectionData(conn models.Connection) {
 	form.GetFormItem(0).(*tview.InputField).SetText(conn.Name)
 	form.GetFormItem(1).(*tview.InputField).SetText(conn.URL)
 	form.GetFormItem(2).(*tview.Checkbox).SetChecked(conn.ReadOnly)
+	form.GetFormItem(3).(*tview.Checkbox).SetChecked(showAllDatabasesChecked(conn))
+}
+
+// showAllDatabasesChecked infers whether the "show all databases" checkbox
+// should be pre-checked when editing an existing connection: true when the
+// connection has no DBName pinned but its URL does carry an embedded
+// database (i.e. it was previously saved with this option enabled, or the
+// user cleared DBName by hand). False for freshly created / legacy
+// connections where DBName mirrors the URL, preserving prior behavior.
+func showAllDatabasesChecked(conn models.Connection) bool {
+	if conn.DBName != "" {
+		return false
+	}
+
+	parsed, err := helpers.ParseConnectionString(conn.URL)
+	if err != nil {
+		return false
+	}
+
+	urlDBName := strings.Split(parsed.Normalize(",", "NULL", 0), ",")[3]
+
+	return urlDBName != "" && urlDBName != "NULL"
 }

--- a/components/connection_form_test.go
+++ b/components/connection_form_test.go
@@ -1,0 +1,68 @@
+package components
+
+import (
+	"testing"
+
+	"github.com/jorgerojas26/lazysql/models"
+)
+
+func TestShowAllDatabasesChecked(t *testing.T) {
+	testCases := []struct {
+		name     string
+		conn     models.Connection
+		expected bool
+	}{
+		{
+			name: "DBName pinned -> unchecked, regardless of URL",
+			conn: models.Connection{
+				URL:    "postgres://user:pass@localhost:5432/mydb",
+				DBName: "mydb",
+			},
+			expected: false,
+		},
+		{
+			name: "DBName empty, URL has embedded database -> checked",
+			conn: models.Connection{
+				URL: "postgres://user:pass@localhost:5432/mydb",
+			},
+			expected: true,
+		},
+		{
+			name: "DBName empty, URL has no embedded database -> unchecked",
+			conn: models.Connection{
+				URL: "postgres://user:pass@localhost:5432/",
+			},
+			expected: false,
+		},
+		{
+			name: "DBName empty, MSSQL URL with embedded database -> checked",
+			conn: models.Connection{
+				URL: "mssql://user:pass@localhost/DADOSADV",
+			},
+			expected: true,
+		},
+		{
+			name: "invalid URL -> unchecked (fail safe)",
+			conn: models.Connection{
+				URL: "not a valid url :: at all",
+			},
+			expected: false,
+		},
+		{
+			name: "empty connection -> unchecked",
+			conn: models.Connection{
+				URL: "",
+			},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := showAllDatabasesChecked(tc.conn)
+			if got != tc.expected {
+				t.Errorf("showAllDatabasesChecked(%+v) = %v, want %v", tc.conn, got, tc.expected)
+			}
+		})
+	}
+}

--- a/components/connection_selection.go
+++ b/components/connection_selection.go
@@ -127,6 +127,8 @@ func NewConnectionSelection(connectionForm *ConnectionForm, connectionPages *mod
 			connectionForm.SetAction(actionNewConnection)
 			connectionForm.GetFormItemByLabel("Name").(*tview.InputField).SetText("")
 			connectionForm.GetFormItemByLabel("URL").(*tview.InputField).SetText("")
+			connectionForm.GetFormItemByLabel("Read-Only").(*tview.Checkbox).SetChecked(false)
+			connectionForm.GetFormItemByLabel("Show all databases in this instance").(*tview.Checkbox).SetChecked(false)
 			connectionForm.StatusText.SetText("")
 			connectionPages.SwitchToPage(pageNameConnectionForm)
 		case commands.Quit:


### PR DESCRIPTION
## What

Adds a **"Show all databases in this instance"** checkbox to the Add/Edit
Connection form, and documents the `DBName` config field in the README.

## Why

`DBName` in `config.toml` controls whether the sidebar tree is pinned to a
single database or lists every database in the instance (via
`GetDatabases()`) — see the discussion in #330, which added cross-database
query execution to the SQL editor.

The problem: `DBName` is **always auto-derived from the database embedded in
the connection URL**, both on connection creation and on every subsequent
edit through the in-app form (`components/connection_form.go`). For
PostgreSQL and MSSQL, a database must be present in the connection string
for the initial authentication to succeed — but that doesn't mean the user
wants the tree limited to only that one database on an instance where their
login is valid for several.

Today, the only way to get multi-database tree browsing is to manually
open `config.toml` in a text editor and delete the `DBName` line by hand —
and that edit is silently undone the next time the connection is opened in
the Edit form and saved, since the form always repopulates `DBName` from
the URL with no way to opt out.

## How

- New checkbox on the connection form, next to the existing `Read-Only`
  checkbox: **"Show all databases in this instance"**.
- When checked, `DBName` is saved as empty regardless of what database is
  present in the connection URL — the tree's `InitializeNodes` then falls
  back to `GetDatabases()` and lists every database in the instance.
- When opening **Edit Connection** on an existing entry, the checkbox is
  automatically inferred from the connection's current state: checked if
  `DBName` is empty but the URL does carry a database (meaning it was
  either saved this way before, or a user cleared it by hand); unchecked
  otherwise. This keeps prior behavior fully intact for connections that
  haven't opted in — no existing config needs to change.
- `New Connection` now also resets both the `Read-Only` and the new
  checkbox, fixing a related small pre-existing gap where `Read-Only`
  could leak checked state from a previous edit session into a fresh "new
  connection" form.
- README: documents what `DBName` does, why PostgreSQL/MSSQL need a
  database in the URL regardless, and how to opt in to multi-database
  browsing either via the new checkbox or by hand-editing `config.toml`.

## Testing

- Added `TestShowAllDatabasesChecked` covering: pinned `DBName` (always
  unchecked), empty `DBName` with an embedded URL database (checked), empty
  `DBName` with no embedded database (unchecked), MSSQL URLs, invalid URLs,
  and empty connections — all passing.
- `go build ./...`, `go vet ./...`, `go test ./...` all pass.
- `gofmt -l .` clean.
- Manually verified end-to-end against a real multi-database PostgreSQL
  instance: unchecking `DBName` via the new checkbox and reopening the
  connection now lists all databases in the sidebar tree, and re-editing
  the same connection correctly shows the checkbox pre-checked.

## Risks / rollback

- Purely additive UI change; default (unchecked) preserves the exact prior
  behavior for every existing connection — no config migration needed.
- The `showAllDatabasesChecked` inference is a pure function with full unit
  test coverage; it fails safe (returns `false`/legacy behavior) on parse
  errors.
- Straightforward revert: this PR touches only the connection form, the
  "new connection" reset flow, and README — no driver or query execution
  code is affected.

## Related

Builds on / complements #330 (cross-database query execution in the SQL
editor for MSSQL, MySQL and PostgreSQL). That PR made it possible to *query*
another database once you're already looking at it in the tree; this PR
makes it possible to actually *see* other databases in the tree in the
first place, without hand-editing the config file.
