### PR TITLE
fix: broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,10 +706,10 @@ Jorge Rojas - [LinkedIn](https://www.linkedin.com/in/jorgerojas26/) - jorgeluisr
 
 ## Star History
 
-<a href="https://www.star-history.com/#jorgerojas26/lazysql&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#jorgerojas26/lazysql&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=jorgerojas26/lazysql&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=jorgerojas26/lazysql&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=jorgerojas26/lazysql&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=jorgerojas26/lazysql&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=jorgerojas26/lazysql&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=jorgerojas26/lazysql&type=date&legend=top-left" />
  </picture>
 </a>


### PR DESCRIPTION
The star history chart in the README is currently broken because of GitHub stargazer API restrictions. This change points it to a working alternative so the chart renders correctly again.