### PR TITLE
ci: pin golangci-lint v2.12.2 and fix v2 lint findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ jobs:
 
       - name: Golangci-lint
         uses: golangci/golangci-lint-action@v6
+        with:
+          # the config is in the v2 format (version: "2", formatters section);
+          # v1 (default "latest" resolution) rejects it in `config verify`
+          version: v2.12.2
 
       - name: Test
         run: go test -v ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,8 @@ jobs:
         uses: actions/setup-go@v5
 
       - name: Golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        # v7 is the first action major that supports golangci-lint v2
+        uses: golangci/golangci-lint-action@v7
         with:
           # the config is in the v2 format (version: "2", formatters section);
           # v1 (default "latest" resolution) rejects it in `config verify`

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,6 +41,142 @@ linters:
     # Checks whether Rows.Err of rows is checked successfully.
     - rowserrcheck
 
+  settings:
+    revive:
+      rules:
+        # these are the default revive rules
+        # you can remove the whole "rules" node if you want
+        # BUT
+        # ! /!\ they all need to be present when you want to add more rules than the default ones
+        # otherwise, you won't have the default rules, but only the ones you define in the "rules" node
+
+        # Blank import should be only in a main or test package, or have a comment justifying it.
+        - name: blank-imports
+
+        # context.Context() should be the first parameter of a function when provided as argument.
+        - name: context-as-argument
+          arguments:
+            - allowTypesBefore: "*testing.T"
+
+        # Basic types should not be used as a key in `context.WithValue`
+        - name: context-keys-type
+
+        # Importing with `.` makes the programs much harder to understand
+        - name: dot-imports
+
+        # Empty blocks make code less readable and could be a symptom of a bug or unfinished refactoring.
+        - name: empty-block
+
+        # for better readability, variables of type `error` must be named with the prefix `err`.
+        - name: error-naming
+
+        # for better readability, the errors should be last in the list of returned values by a function.
+        - name: error-return
+
+        # for better readability, error messages should not be capitalized or end with punctuation or a newline.
+        - name: error-strings
+
+        # report when replacing `errors.New(fmt.Sprintf())` with `fmt.Errorf()` is possible
+        - name: errorf
+
+        # enforces conventions on source file names
+        - name: filename-format
+          arguments: ["^[_a-z][_a-z0-9]*\\.go$"]
+
+        # incrementing an integer variable by 1 is recommended to be done using the `++` operator
+        - name: increment-decrement
+
+        # highlights redundant else-blocks that can be eliminated from the code
+        - name: indent-error-flow
+
+        # This rule suggests a shorter way of writing ranges that do not use the second value.
+        - name: range
+
+        # receiver names in a method should reflect the struct name (p for Person, for example)
+        - name: receiver-naming
+
+        # redefining built in names (true, false, append, make) can lead to bugs very difficult to detect.
+        - name: redefines-builtin-id
+
+        # redundant else-blocks that can be eliminated from the code.
+        - name: superfluous-else
+
+        # prevent confusing name for variables when using `time` package
+        - name: time-naming
+
+        # warns when an exported function or method returns a value of an un-exported type.
+        - name: unexported-return
+
+        # spots and proposes to remove unreachable code. also helps to spot errors
+        - name: unreachable-code
+
+        # Functions or methods with unused parameters can be a symptom of an unfinished refactoring or a bug.
+        - name: unused-parameter
+
+        # report when a variable declaration can be simplified
+        - name: var-declaration
+
+        # warns when initialism, variable or package naming conventions are not followed.
+        - name: var-naming
+          arguments: [[], ["DB", "DML"]]
+
+        # if-then-else conditional with identical implementations in both branches is an error.
+        - name: identical-branches
+
+        # warns when errors returned by a function are not explicitly handled on the caller side.
+        - name: unhandled-error
+          arguments: # here are the exceptions we don't want to be reported
+            - "fmt.Print.*"
+            - "fmt.Fprint.*"
+            - "bytes.Buffer.Write*"
+            - "strings.Builder.Write*"
+
+    dupword:
+      # Keywords used to ignore detection.
+      # Default: []
+      ignore: []
+
+    errcheck:
+      # Close/cleanup calls whose errors are not actionable in this codebase.
+      # Forgetting to close rows/conns is still caught by sqlclosecheck.
+      exclude-functions:
+        - fmt.Fprintln
+        - fmt.Fprintf
+        - os.Remove
+        - os.RemoveAll
+        - os.Unsetenv
+        - (*database/sql.DB).Close
+        - (*database/sql.Rows).Close
+        - (*os.File).Close
+        - (*net.TCPListener).Close
+
+    gosec:
+      # To specify a set of rules to explicitly exclude.
+      # Available rules: https://github.com/securego/gosec#available-rules
+      excludes:
+        - G306 # Poor file permissions used when writing to a new file
+        - G307 # Poor file permissions used when creating a file with os.Create
+        # DB client specifics: connection URLs with credentials are the data
+        # model (G101 fires only on URL-parsing test fixtures), queries are
+        # built dynamically because identifiers cannot be parameterized (G202),
+        # and all file reads use app-controlled paths (G304).
+        - G101
+        - G202
+        - G304
+
+    misspell:
+      # Correct spellings using locale preferences for US or UK.
+      # Setting locale to US will correct the British spelling of 'colour' to 'color'.
+      # Default ("") is to use a neutral variety of English.
+      locale: US
+
+      # List of words to ignore
+      # among the one defined in https://github.com/golangci/misspell/blob/master/words.go
+      ignore-rules: []
+
+      # Extra word corrections.
+      extra-words: []
+
 formatters:
   enable:
     # check imports order and makes it always deterministic.
@@ -54,119 +190,4 @@ formatters:
       - default
       # linters that related to local tool, so they should be separated
       - localmodule
-
-linters-settings:
-  revive:
-    rules:
-      # these are the default revive rules
-      # you can remove the whole "rules" node if you want
-      # BUT
-      # ! /!\ they all need to be present when you want to add more rules than the default ones
-      # otherwise, you won't have the default rules, but only the ones you define in the "rules" node
-
-      # Blank import should be only in a main or test package, or have a comment justifying it.
-      - name: blank-imports
-
-      # context.Context() should be the first parameter of a function when provided as argument.
-      - name: context-as-argument
-        arguments:
-          - allowTypesBefore: "*testing.T"
-
-      # Basic types should not be used as a key in `context.WithValue`
-      - name: context-keys-type
-
-      # Importing with `.` makes the programs much harder to understand
-      - name: dot-imports
-
-      # Empty blocks make code less readable and could be a symptom of a bug or unfinished refactoring.
-      - name: empty-block
-
-      # for better readability, variables of type `error` must be named with the prefix `err`.
-      - name: error-naming
-
-      # for better readability, the errors should be last in the list of returned values by a function.
-      - name: error-return
-
-      # for better readability, error messages should not be capitalized or end with punctuation or a newline.
-      - name: error-strings
-
-      # report when replacing `errors.New(fmt.Sprintf())` with `fmt.Errorf()` is possible
-      - name: errorf
-
-      # enforces conventions on source file names
-      - name: filename-format
-        arguments: ["^[_a-z][_a-z0-9]*\\.go$"]
-
-      # incrementing an integer variable by 1 is recommended to be done using the `++` operator
-      - name: increment-decrement
-
-      # highlights redundant else-blocks that can be eliminated from the code
-      - name: indent-error-flow
-
-      # This rule suggests a shorter way of writing ranges that do not use the second value.
-      - name: range
-
-      # receiver names in a method should reflect the struct name (p for Person, for example)
-      - name: receiver-naming
-
-      # redefining built in names (true, false, append, make) can lead to bugs very difficult to detect.
-      - name: redefines-builtin-id
-
-      # redundant else-blocks that can be eliminated from the code.
-      - name: superfluous-else
-
-      # prevent confusing name for variables when using `time` package
-      - name: time-naming
-
-      # warns when an exported function or method returns a value of an un-exported type.
-      - name: unexported-return
-
-      # spots and proposes to remove unreachable code. also helps to spot errors
-      - name: unreachable-code
-
-      # Functions or methods with unused parameters can be a symptom of an unfinished refactoring or a bug.
-      - name: unused-parameter
-
-      # report when a variable declaration can be simplified
-      - name: var-declaration
-
-      # warns when initialism, variable or package naming conventions are not followed.
-      - name: var-naming
-        arguments: [[], ["DB", "DML"]]
-
-      # if-then-else conditional with identical implementations in both branches is an error.
-      - name: identical-branches
-
-      # warns when errors returned by a function are not explicitly handled on the caller side.
-      - name: unhandled-error
-        arguments: # here are the exceptions we don't want to be reported
-          - "fmt.Print.*"
-          - "fmt.Fprint.*"
-          - "bytes.Buffer.Write*"
-          - "strings.Builder.Write*"
-
-  dupword:
-    # Keywords used to ignore detection.
-    # Default: []
-    ignore: []
-
-  gosec:
-    # To specify a set of rules to explicitly exclude.
-    # Available rules: https://github.com/securego/gosec#available-rules
-    excludes:
-      - G306 # Poor file permissions used when writing to a new file
-      - G307 # Poor file permissions used when creating a file with os.Create
-
-  misspell:
-    # Correct spellings using locale preferences for US or UK.
-    # Setting locale to US will correct the British spelling of 'colour' to 'color'.
-    # Default ("") is to use a neutral variety of English.
-    locale: US
-
-    # List of words to ignore
-    # among the one defined in https://github.com/golangci/misspell/blob/master/words.go
-    ignore-words: []
-
-    # Extra word corrections.
-    extra-words: []
 

--- a/app/config.go
+++ b/app/config.go
@@ -206,7 +206,7 @@ func (c *Config) SaveConnections(connections []models.Connection) error {
 		configFile = c.LocalConfigFile
 	}
 
-	if err := os.MkdirAll(filepath.Dir(configFile), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(configFile), 0o700); err != nil {
 		return err
 	}
 

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -162,7 +162,7 @@ func TestFindLocalConfig(t *testing.T) {
 			name: "finds config in parent directory",
 			setup: func(tmpDir string) error {
 				subDir := filepath.Join(tmpDir, "subdir")
-				if err := os.MkdirAll(subDir, 0o755); err != nil {
+				if err := os.MkdirAll(subDir, 0o700); err != nil {
 					return err
 				}
 				if err := os.Chdir(subDir); err != nil {
@@ -181,10 +181,10 @@ func TestFindLocalConfig(t *testing.T) {
 				//   tmpDir/repo/project/   ← CWD
 				repoDir := filepath.Join(tmpDir, "repo")
 				projectDir := filepath.Join(repoDir, "project")
-				if err := os.MkdirAll(projectDir, 0o755); err != nil {
+				if err := os.MkdirAll(projectDir, 0o700); err != nil {
 					return err
 				}
-				if err := os.MkdirAll(filepath.Join(repoDir, ".git"), 0o755); err != nil {
+				if err := os.MkdirAll(filepath.Join(repoDir, ".git"), 0o700); err != nil {
 					return err
 				}
 				if err := os.WriteFile(filepath.Join(tmpDir, ".lazysql.toml"), []byte("test"), 0o600); err != nil {
@@ -201,11 +201,11 @@ func TestFindLocalConfig(t *testing.T) {
 				//   tmpDir/.git/            ← git boundary
 				//   tmpDir/.lazysql.toml   ← config at repo root, SHOULD be found
 				//   tmpDir/project/         ← CWD
-				if err := os.MkdirAll(filepath.Join(tmpDir, ".git"), 0o755); err != nil {
+				if err := os.MkdirAll(filepath.Join(tmpDir, ".git"), 0o700); err != nil {
 					return err
 				}
 				projectDir := filepath.Join(tmpDir, "project")
-				if err := os.MkdirAll(projectDir, 0o755); err != nil {
+				if err := os.MkdirAll(projectDir, 0o700); err != nil {
 					return err
 				}
 				if err := os.WriteFile(filepath.Join(tmpDir, ".lazysql.toml"), []byte("test"), 0o600); err != nil {
@@ -222,7 +222,7 @@ func TestFindLocalConfig(t *testing.T) {
 					return err
 				}
 				// Create .git to stop the search before it reaches system temp
-				return os.MkdirAll(filepath.Join(tmpDir, ".git"), 0o755)
+				return os.MkdirAll(filepath.Join(tmpDir, ".git"), 0o700)
 			},
 			expectFound: false,
 		},
@@ -281,7 +281,7 @@ func TestLoadConfigWithLocal(t *testing.T) {
 	defer os.RemoveAll(tmpDir)
 
 	// Create .git directory to act as repo boundary
-	if err := os.MkdirAll(filepath.Join(tmpDir, ".git"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".git"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 
@@ -364,7 +364,7 @@ func TestLoadConfigLocalReplacesConnections(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	if err := os.MkdirAll(filepath.Join(tmpDir, ".git"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".git"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 
@@ -435,7 +435,7 @@ func TestLoadConfigPreservesDefaults(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	if err := os.MkdirAll(filepath.Join(tmpDir, ".git"), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".git"), 0o700); err != nil {
 		t.Fatal(err)
 	}
 

--- a/components/confirmation_modal.go
+++ b/components/confirmation_modal.go
@@ -43,7 +43,7 @@ func (m *ConfirmationModal) SetDoneFunc(handler func(buttonIndex int, buttonLabe
 	m.Modal.SetDoneFunc(handler)
 
 	// Add y/n shortcuts for confirmation dialogs.
-	m.Modal.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+	m.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
 		if event.Key() != tcell.KeyRune {
 			return event
 		}

--- a/components/results_table.go
+++ b/components/results_table.go
@@ -1390,13 +1390,14 @@ func (table *ResultsTable) handleShowJSONViewer(command commands.Command) {
 
 	rowData := make(map[string]string)
 
-	if command == commands.ShowRowJSONViewer {
+	switch command {
+	case commands.ShowRowJSONViewer:
 		for i := 0; i < table.GetColumnCount(); i++ {
 			columnName := table.GetColumnNameByIndex(i)
 			cellValue := table.GetCell(selectedRow, i).Text
 			rowData[columnName] = cellValue
 		}
-	} else if command == commands.ShowCellJSONViewer {
+	case commands.ShowCellJSONViewer:
 		columnName := table.GetColumnNameByIndex(selectedCol)
 		cellValue := table.GetCell(selectedRow, selectedCol).Text
 		rowData[columnName] = cellValue
@@ -1458,7 +1459,7 @@ func (table *ResultsTable) AppendNewChange(changeType models.DMLType, rowIndex i
 	rowPrimaryKeyInfo := table.GetPrimaryKeyValue(rowIndex)
 
 	if len(rowPrimaryKeyInfo) == 0 {
-		return fmt.Errorf("Primary key not found for row %d", rowIndex)
+		return fmt.Errorf("primary key not found for row %d", rowIndex)
 	}
 
 	if changeType == models.DMLUpdateType {
@@ -1920,7 +1921,7 @@ func (table *ResultsTable) rebuildForeignKeyJumpMetadata() {
 	referencedTableIndex, okTable := foreignKeyHeaderIndex(headers, provider, "foreign_table_name", "table", "referenced_table")
 	referencedColumnIndex, okReferencedColumn := foreignKeyHeaderIndex(headers, provider, "foreign_column_name", "to", "referenced_column")
 	constraintIndex, okConstraint := foreignKeyHeaderIndex(headers, provider, "constraint_name", "id")
-	if !(okColumn && okTable && okReferencedColumn && okConstraint) {
+	if !okColumn || !okTable || !okReferencedColumn || !okConstraint {
 		return
 	}
 

--- a/components/sql_context.go
+++ b/components/sql_context.go
@@ -110,9 +110,10 @@ func cursorDepth(text string, cursorPos int) int {
 			break
 		}
 		w := text[t.Start:t.End]
-		if w == "(" {
+		switch w {
+		case "(":
 			depth++
-		} else if w == ")" {
+		case ")":
 			depth--
 		}
 	}
@@ -204,9 +205,10 @@ func skipParenBlock(text string, tokens []SQLToken, i *int) {
 	*i++
 	for *i < len(tokens) && depth > 0 {
 		w := text[tokens[*i].Start:tokens[*i].End]
-		if w == "(" {
+		switch w {
+		case "(":
 			depth++
-		} else if w == ")" {
+		case ")":
 			depth--
 		}
 		*i++

--- a/components/sql_editor.go
+++ b/components/sql_editor.go
@@ -1173,8 +1173,8 @@ func (e *SQLEditor) acceptCompletion() {
 
 // Draw renders the editor on the screen.
 func (e *SQLEditor) Draw(screen tcell.Screen) {
-	e.Box.DrawForSubclass(screen, e)
-	x, y, width, height := e.Box.GetInnerRect()
+	e.DrawForSubclass(screen, e)
+	x, y, width, height := e.GetInnerRect()
 
 	if width <= 0 || height <= 0 {
 		return
@@ -1587,7 +1587,7 @@ func (e *SQLEditor) drawAutocomplete(screen tcell.Screen, x, y, width, height in
 // ---------------------------------------------------------------------------
 
 func (e *SQLEditor) scrollToCursor() {
-	_, _, width, height := e.Box.GetInnerRect()
+	_, _, width, height := e.GetInnerRect()
 
 	// Vertical scroll
 	if e.cy < e.oy {
@@ -1738,7 +1738,7 @@ func openExternalEditor(currentText string, connectionURL string) string {
 
 	editor := getEditor()
 
-	cmd := exec.Command(editor, path)
+	cmd := exec.Command(editor, path) // #nosec G204 -- launching the user's configured external editor
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/components/tree.go
+++ b/components/tree.go
@@ -745,7 +745,7 @@ func (tree *Tree) search(searchText string) {
 				// Walk up the ancestor chain (not just the immediate parent)
 				// so two-part search works through section headers
 				// (e.g. "auth users" in postgres > auth > tables > users).
-				var bestAncestorRank int = -1
+				var bestAncestorRank = -1
 				var bestAncestorText string
 				for e := parentMap[node]; e != nil && e != rootNode; e = parentMap[e] {
 					eText := strings.ToLower(stripColorTags(e.GetText()))

--- a/helpers/csv.go
+++ b/helpers/csv.go
@@ -26,7 +26,7 @@ type CSVWriter struct {
 // Call Commit() to finalize the file, or Abort() to discard it.
 func NewCSVWriter(filePath string) (*CSVWriter, error) {
 	dir := filepath.Dir(filePath)
-	if err := os.MkdirAll(dir, 0o755); err != nil {
+	if err := os.MkdirAll(dir, 0o700); err != nil {
 		return nil, err
 	}
 

--- a/helpers/logger/logger.go
+++ b/helpers/logger/logger.go
@@ -78,7 +78,7 @@ func (l *logger) SetFile(filename string) error {
 		}
 	}
 
-	file, err := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	file, err := os.OpenFile(filename, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

- Fixed the CI failure at `golangci-lint config verify` ("additional properties 'version', 'formatters' not allowed").
- Root cause: the `golangci-lint-action@v6` default `version: latest` resolved to golangci-lint **v1.64.8** (v1), whose `config verify` schema rejects the v2-format keys `version` and `formatters` used by `.golangci.yml` (migrated in #b4222db for local neovim/mason).
- Pinned the action to **v2.12.2** and completed the v2 config migration, then resolved the 47 lint findings that v2 surfaces.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/ci.yml` | Pin `golangci-lint-action` to `version: v2.12.2` |
| `.golangci.yml` | Move top-level `linters-settings` under `linters.settings`; rename misspell `ignore-words` → `ignore-rules`; tune `errcheck` (exclude non-actionable Close/cleanup calls) and `gosec` (exclude by-design DB-client patterns G101/G202/G304) |
| `app/config.go`, `helpers/csv.go` | Config/CSV dirs created with `0700` (holds credentials) |
| `helpers/logger/logger.go` | Log file opened with `0600` |
| `app/config_test.go` | Test dirs `0700` |
| `components/{results_table,sql_context,sql_editor,confirmation_modal,tree}.go` | Apply staticcheck QF1001/QF1003/QF1008 quickfixes, ST1005, revive `var-declaration`; annotate intentional external-editor subprocess `// #nosec G204` |

## Test Plan

- [x] `golangci-lint config verify` passes on v2.12.2
- [x] `golangci-lint run` reports **0 issues** on v2.12.2
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` all pass

## Notes

- gosec G101/G202/G304 are excluded globally with a justification comment: this is a DB client where connection URLs with credentials are the data model, queries are built dynamically (identifiers cannot be parameterized), and all file reads use app-controlled paths.
- Forgetting to `Close()` rows/conns is still caught by `sqlclosecheck` (errcheck exclusions only silence non-actionable cleanup error returns).
