### PR TITLE
[bugfix] Broken focus on active table tab when 5+ tabs open

### DIFF
--- a/components/tabbed_menu.go
+++ b/components/tabbed_menu.go
@@ -31,11 +31,15 @@ type TabbedPaneState struct {
 	Length     int
 }
 
+const headerArrowMaxWidth = 3
+
 type TabbedPane struct {
 	*tview.Pages
-	HeaderContainer *tview.Grid
-	state           *TabbedPaneState
-	headerWidths    []int
+	HeaderContainer      *tview.Grid
+	state                *TabbedPaneState
+	headerWidths         []int
+	headerHasHiddenLeft  bool
+	headerHasHiddenRight bool
 }
 
 func NewTabbedPane() *TabbedPane {
@@ -50,8 +54,34 @@ func NewTabbedPane() *TabbedPane {
 	}
 
 	container.SetDrawFunc(func(screen tcell.Screen, x, y, width, height int) (int, int, int, int) {
-		tabbedPane.alignHeaderToWidth(width - 2)
-		return x + 1, y, width - 2, height
+		innerWidth := width - 2
+
+		leftReserve, rightReserve := 0, 0
+		for {
+			tabbedPane.alignHeaderToWidth(innerWidth - leftReserve - rightReserve)
+
+			newLeft, newRight := 0, 0
+			if tabbedPane.headerHasHiddenLeft {
+				newLeft = headerArrowMaxWidth
+			}
+			if tabbedPane.headerHasHiddenRight {
+				newRight = headerArrowMaxWidth
+			}
+
+			if newLeft == leftReserve && newRight == rightReserve {
+				break
+			}
+			leftReserve, rightReserve = newLeft, newRight
+		}
+
+		if tabbedPane.headerHasHiddenLeft {
+			tview.Print(screen, "<< ", x+1, y, leftReserve, tview.AlignLeft, app.Styles.TertiaryTextColor)
+		}
+		if tabbedPane.headerHasHiddenRight {
+			tview.Print(screen, " >>", x+1+innerWidth-rightReserve, y, rightReserve, tview.AlignRight, app.Styles.TertiaryTextColor)
+		}
+
+		return x + 1 + leftReserve, y, innerWidth - leftReserve - rightReserve, height
 	})
 
 	return tabbedPane
@@ -189,6 +219,9 @@ func (t *TabbedPane) AlignHeaderToCurrentTab() {
 }
 
 func (t *TabbedPane) alignHeaderToWidth(width int) {
+	t.headerHasHiddenLeft = false
+	t.headerHasHiddenRight = false
+
 	if width <= 0 {
 		t.HeaderContainer.SetOffset(0, 0)
 		return
@@ -214,6 +247,19 @@ func (t *TabbedPane) alignHeaderToWidth(width int) {
 		used += t.headerWidths[i]
 		target = i
 	}
+
+	visibleColumns := 0
+	used = 0
+	for i := target; i < len(t.headerWidths); i++ {
+		if used+t.headerWidths[i] > width {
+			break
+		}
+		used += t.headerWidths[i]
+		visibleColumns++
+	}
+
+	t.headerHasHiddenLeft = target > 0
+	t.headerHasHiddenRight = visibleColumns < len(t.headerWidths)-target
 
 	t.HeaderContainer.SetOffset(0, target)
 }

--- a/components/tabbed_menu.go
+++ b/components/tabbed_menu.go
@@ -1,6 +1,7 @@
 package components
 
 import (
+	"github.com/gdamore/tcell/v2"
 	"github.com/rivo/tview"
 
 	"github.com/jorgerojas26/lazysql/app"
@@ -32,19 +33,26 @@ type TabbedPaneState struct {
 
 type TabbedPane struct {
 	*tview.Pages
-	HeaderContainer *tview.Flex
+	HeaderContainer *tview.Grid
 	state           *TabbedPaneState
+	headerWidths    []int
 }
 
 func NewTabbedPane() *TabbedPane {
-	container := tview.NewFlex()
+	container := tview.NewGrid()
 	container.SetBorderPadding(0, 0, 1, 1)
+	container.SetRows(1)
 
 	tabbedPane := &TabbedPane{
 		Pages:           tview.NewPages(),
 		HeaderContainer: container,
 		state:           &TabbedPaneState{},
 	}
+
+	container.SetDrawFunc(func(screen tcell.Screen, x, y, width, height int) (int, int, int, int) {
+		tabbedPane.alignHeaderToWidth(width - 2)
+		return x + 1, y, width - 2, height
+	})
 
 	return tabbedPane
 }
@@ -74,9 +82,11 @@ func (t *TabbedPane) AppendTab(name string, content TabContent, reference string
 		t.state.CurrentTab = newTab
 	}
 
-	t.HeaderContainer.AddItem(newTab.Header, len(newTab.Name)+2, 0, false)
+	t.headerWidths = append(t.headerWidths, len(newTab.Name)+2)
+	t.rebuildHeaderStrip()
 
 	t.HighlightTabHeader(newTab)
+	t.AlignHeaderToCurrentTab()
 
 	t.AddAndSwitchToPage(reference, content.GetPrimitive(), true)
 }
@@ -85,6 +95,14 @@ func (t *TabbedPane) RemoveCurrentTab() *Tab {
 	currentTab := t.state.CurrentTab
 
 	if currentTab != nil {
+		index := 0
+		for tab := t.state.FirstTab; tab != nil; tab = tab.NextTab {
+			if tab == currentTab {
+				break
+			}
+			index++
+		}
+
 		t.HeaderContainer.RemoveItem(currentTab.Header)
 		t.RemovePage(currentTab.Reference)
 
@@ -94,6 +112,10 @@ func (t *TabbedPane) RemoveCurrentTab() *Tab {
 			t.state.FirstTab = nil
 			t.state.LastTab = nil
 			t.state.CurrentTab = nil
+
+			t.headerWidths = nil
+			t.rebuildHeaderStrip()
+
 			return nil
 		}
 
@@ -112,6 +134,11 @@ func (t *TabbedPane) RemoveCurrentTab() *Tab {
 			currentTab.NextTab.PreviousTab = currentTab.PreviousTab
 		}
 
+		if index < len(t.headerWidths) {
+			t.headerWidths = append(t.headerWidths[:index], t.headerWidths[index+1:]...)
+		}
+		t.rebuildHeaderStrip()
+
 		if currentTab.PreviousTab != nil {
 			t.SetCurrentTab(currentTab.PreviousTab)
 			return currentTab.PreviousTab
@@ -129,9 +156,66 @@ func (t *TabbedPane) SetCurrentTab(tab *Tab) *Tab {
 
 	t.SwitchToPage(tab.Reference)
 
+	t.AlignHeaderToCurrentTab()
+
 	app.App.SetFocus(tab.Content.GetPrimitive())
 
 	return tab
+}
+
+func (t *TabbedPane) rebuildHeaderStrip() {
+	t.HeaderContainer.Clear()
+
+	if len(t.headerWidths) == 0 {
+		t.HeaderContainer.SetColumns()
+		return
+	}
+
+	t.HeaderContainer.SetColumns(t.headerWidths...)
+
+	tab := t.state.FirstTab
+	for i := 0; tab != nil && i < len(t.headerWidths); i++ {
+		t.HeaderContainer.AddItem(tab.Header, 0, i, 1, 1, 1, t.headerWidths[i], false)
+		tab = tab.NextTab
+	}
+}
+
+func (t *TabbedPane) AlignHeaderToCurrentTab() {
+	if t.state.CurrentTab == nil || len(t.headerWidths) == 0 {
+		return
+	}
+	_, _, width, _ := t.HeaderContainer.GetInnerRect()
+	t.alignHeaderToWidth(width)
+}
+
+func (t *TabbedPane) alignHeaderToWidth(width int) {
+	if width <= 0 {
+		t.HeaderContainer.SetOffset(0, 0)
+		return
+	}
+
+	index := 0
+	for tab := t.state.FirstTab; tab != nil; tab = tab.NextTab {
+		if tab == t.state.CurrentTab {
+			break
+		}
+		index++
+	}
+	if index >= len(t.headerWidths) {
+		return
+	}
+
+	used := t.headerWidths[index]
+	target := index
+	for i := index - 1; i >= 0; i-- {
+		if used+t.headerWidths[i] > width {
+			break
+		}
+		used += t.headerWidths[i]
+		target = i
+	}
+
+	t.HeaderContainer.SetOffset(0, target)
 }
 
 func (t *TabbedPane) GetCurrentTab() *Tab {

--- a/components/tabbed_menu.go
+++ b/components/tabbed_menu.go
@@ -44,6 +44,7 @@ type TabbedPane struct {
 	headerWidths         []int
 	headerHasHiddenLeft  bool
 	headerHasHiddenRight bool
+	headerRightShift     int
 }
 
 func NewTabbedPane() *TabbedPane {
@@ -96,7 +97,12 @@ func NewTabbedPane() *TabbedPane {
 			tview.Print(screen, " ▶", x+1+innerWidth-rightReserve, y, rightReserve, tview.AlignRight, app.Styles.GraphicsColor)
 		}
 
-		return x + 1 + leftReserve, y, availWidth, height
+		// When the strip has scrolled to the last tab and does not fill the
+		// available width, right-align it so the active tab touches the right
+		// edge instead of leaving dead space after it.
+		shift := tabbedPane.headerRightShift
+
+		return x + 1 + leftReserve + shift, y, availWidth - shift, height
 	})
 
 	return tabbedPane
@@ -239,6 +245,7 @@ func (t *TabbedPane) AlignHeaderToCurrentTab() {
 func (t *TabbedPane) alignHeaderToWidth(width int) {
 	t.headerHasHiddenLeft = false
 	t.headerHasHiddenRight = false
+	t.headerRightShift = 0
 
 	if width <= 0 || len(t.headerWidths) == 0 {
 		t.HeaderContainer.SetOffset(0, 0)
@@ -278,6 +285,13 @@ func (t *TabbedPane) alignHeaderToWidth(width int) {
 
 	t.headerHasHiddenLeft = target > 0
 	t.headerHasHiddenRight = visibleColumns < len(t.headerWidths)-target
+
+	// Reaching the last tab parks the remaining tabs flush against the right
+	// edge of the available space (only when the strip is scrolled, so tabs
+	// that all fit stay left-aligned like a browser bar).
+	if t.headerHasHiddenLeft && !t.headerHasHiddenRight && t.state.CurrentTab == t.state.LastTab && used < width {
+		t.headerRightShift = width - used
+	}
 
 	t.HeaderContainer.SetOffset(0, target)
 }

--- a/components/tabbed_menu.go
+++ b/components/tabbed_menu.go
@@ -31,7 +31,11 @@ type TabbedPaneState struct {
 	Length     int
 }
 
-const headerArrowMaxWidth = 3
+const (
+	// headerArrowWidth is the number of columns reserved on each side of the
+	// header strip to show that tabs are hidden outside the visible area.
+	headerArrowWidth = 2
+)
 
 type TabbedPane struct {
 	*tview.Pages
@@ -57,15 +61,26 @@ func NewTabbedPane() *TabbedPane {
 		innerWidth := width - 2
 
 		leftReserve, rightReserve := 0, 0
+		availWidth := innerWidth
 		for {
-			tabbedPane.alignHeaderToWidth(innerWidth - leftReserve - rightReserve)
+			availWidth = innerWidth - leftReserve - rightReserve
+			if availWidth <= 0 {
+				// Not enough room left for the arrows: drop them instead of
+				// oscillating between reserving and releasing space.
+				leftReserve, rightReserve = 0, 0
+				availWidth = innerWidth
+				tabbedPane.alignHeaderToWidth(availWidth)
+				break
+			}
+
+			tabbedPane.alignHeaderToWidth(availWidth)
 
 			newLeft, newRight := 0, 0
 			if tabbedPane.headerHasHiddenLeft {
-				newLeft = headerArrowMaxWidth
+				newLeft = headerArrowWidth
 			}
 			if tabbedPane.headerHasHiddenRight {
-				newRight = headerArrowMaxWidth
+				newRight = headerArrowWidth
 			}
 
 			if newLeft == leftReserve && newRight == rightReserve {
@@ -74,14 +89,14 @@ func NewTabbedPane() *TabbedPane {
 			leftReserve, rightReserve = newLeft, newRight
 		}
 
-		if tabbedPane.headerHasHiddenLeft {
-			tview.Print(screen, "<< ", x+1, y, leftReserve, tview.AlignLeft, app.Styles.TertiaryTextColor)
+		if leftReserve > 0 {
+			tview.Print(screen, "◀ ", x+1, y, leftReserve, tview.AlignLeft, app.Styles.GraphicsColor)
 		}
-		if tabbedPane.headerHasHiddenRight {
-			tview.Print(screen, " >>", x+1+innerWidth-rightReserve, y, rightReserve, tview.AlignRight, app.Styles.TertiaryTextColor)
+		if rightReserve > 0 {
+			tview.Print(screen, " ▶", x+1+innerWidth-rightReserve, y, rightReserve, tview.AlignRight, app.Styles.GraphicsColor)
 		}
 
-		return x + 1 + leftReserve, y, innerWidth - leftReserve - rightReserve, height
+		return x + 1 + leftReserve, y, availWidth, height
 	})
 
 	return tabbedPane
@@ -90,6 +105,7 @@ func NewTabbedPane() *TabbedPane {
 func (t *TabbedPane) AppendTab(name string, content TabContent, reference string) {
 	textView := tview.NewTextView()
 	textView.SetText(name)
+	textView.SetTextAlign(tview.AlignCenter)
 	item := &Header{textView}
 
 	newTab := &Tab{
@@ -205,7 +221,9 @@ func (t *TabbedPane) rebuildHeaderStrip() {
 
 	tab := t.state.FirstTab
 	for i := 0; tab != nil && i < len(t.headerWidths); i++ {
-		t.HeaderContainer.AddItem(tab.Header, 0, i, 1, 1, 1, t.headerWidths[i], false)
+		// minGridWidth is 1 so tabs are still drawn (clipped) in narrow
+		// terminals instead of being skipped by the grid.
+		t.HeaderContainer.AddItem(tab.Header, 0, i, 1, 1, 1, 1, false)
 		tab = tab.NextTab
 	}
 }
@@ -222,7 +240,7 @@ func (t *TabbedPane) alignHeaderToWidth(width int) {
 	t.headerHasHiddenLeft = false
 	t.headerHasHiddenRight = false
 
-	if width <= 0 {
+	if width <= 0 || len(t.headerWidths) == 0 {
 		t.HeaderContainer.SetOffset(0, 0)
 		return
 	}
@@ -378,36 +396,30 @@ func (t *TabbedPane) SwitchToTabByReference(reference string) *Tab {
 }
 
 func (t *TabbedPane) HighlightTabHeader(tab *Tab) {
-	tabToHighlight := t.state.FirstTab
-
-	for i := 0; tabToHighlight != nil && i < t.state.Length; i++ {
-		if tabToHighlight.Header == tab.Header {
-			tabToHighlight.Header.SetTextColor(app.Styles.SecondaryTextColor)
-		} else {
-			tabToHighlight.Header.SetTextColor(app.Styles.PrimaryTextColor)
-		}
-		tabToHighlight = tabToHighlight.NextTab
-	}
+	t.styleHeaders(tab, app.Styles.PrimaryTextColor)
 }
 
 func (t *TabbedPane) Highlight() {
-	tab := t.state.FirstTab
-
-	for i := 0; tab != nil && i < t.state.Length; i++ {
-		if tab == t.state.CurrentTab {
-			tab.Header.SetTextColor(app.Styles.SecondaryTextColor)
-		} else {
-			tab.Header.SetTextColor(app.Styles.PrimaryTextColor)
-		}
-		tab = tab.NextTab
-	}
+	t.styleHeaders(t.state.CurrentTab, app.Styles.PrimaryTextColor)
 }
 
 func (t *TabbedPane) SetBlur() {
-	tab := t.state.FirstTab
+	t.styleHeaders(t.state.CurrentTab, app.Styles.InverseTextColor)
+}
 
-	for i := 0; tab != nil && i < t.state.Length; i++ {
-		tab.Header.SetTextColor(app.Styles.InverseTextColor)
-		tab = tab.NextTab
+// styleHeaders paints the selected tab with a solid background and every other
+// tab with plain text. The selected tab keeps its highlight while the pane is
+// blurred so the active table stays identifiable.
+func (t *TabbedPane) styleHeaders(selected *Tab, normalColor tcell.Color) {
+	selectedStyle := tcell.StyleDefault.
+		Background(app.Styles.SecondaryTextColor).
+		Foreground(app.Styles.ContrastSecondaryTextColor)
+
+	for tab := t.state.FirstTab; tab != nil; tab = tab.NextTab {
+		if tab == selected {
+			tab.Header.SetTextStyle(selectedStyle)
+			continue
+		}
+		tab.Header.SetTextStyle(tcell.StyleDefault.Foreground(normalColor))
 	}
 }

--- a/components/tabbed_menu_test.go
+++ b/components/tabbed_menu_test.go
@@ -97,3 +97,55 @@ func TestAlignHeaderToWidth(t *testing.T) {
 		})
 	}
 }
+
+func TestHeaderRightShift(t *testing.T) {
+	tests := []struct {
+		name      string
+		names     []string
+		current   string
+		width     int
+		wantShift int
+	}{
+		{
+			name:      "scrolled to the last tab parks the strip at the right edge",
+			names:     []string{"users", "orders", "products", "invoices", "sessions"},
+			current:   "sessions",
+			width:     36,
+			wantShift: 6, // 36 - (10 + 10 + 10)
+		},
+		{
+			name:      "exact fit leaves no shift",
+			names:     []string{"users", "orders", "products", "invoices", "sessions"},
+			current:   "sessions",
+			width:     30,
+			wantShift: 0,
+		},
+		{
+			name:      "all tabs fit keeps the strip left-aligned",
+			names:     []string{"users", "orders", "products", "invoices", "sessions"},
+			current:   "sessions",
+			width:     80,
+			wantShift: 0,
+		},
+		{
+			name:      "middle tab never shifts",
+			names:     []string{"users", "orders", "products", "invoices", "sessions"},
+			current:   "products",
+			width:     36,
+			wantShift: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pane := newTestTabbedPane(t, tt.names...)
+			pane.SetCurrentTab(pane.GetTabByName(tt.current))
+
+			pane.alignHeaderToWidth(tt.width)
+
+			if pane.headerRightShift != tt.wantShift {
+				t.Errorf("rightShift = %d, want %d", pane.headerRightShift, tt.wantShift)
+			}
+		})
+	}
+}

--- a/components/tabbed_menu_test.go
+++ b/components/tabbed_menu_test.go
@@ -1,0 +1,99 @@
+package components
+
+import (
+	"testing"
+
+	"github.com/rivo/tview"
+)
+
+type stubTabContent struct{}
+
+func (stubTabContent) GetPrimitive() tview.Primitive { return tview.NewBox() }
+
+func newTestTabbedPane(t *testing.T, names ...string) *TabbedPane {
+	t.Helper()
+
+	pane := NewTabbedPane()
+	for _, name := range names {
+		pane.AppendTab(name, stubTabContent{}, name)
+	}
+	return pane
+}
+
+func TestAlignHeaderToWidth(t *testing.T) {
+	tests := []struct {
+		name        string
+		names       []string
+		current     string
+		width       int
+		wantOffset  int
+		wantHiddenL bool
+		wantHiddenR bool
+	}{
+		{
+			name:        "all tabs fit keeps the strip unscrolled",
+			names:       []string{"users", "orders", "products"},
+			current:     "products",
+			width:       80,
+			wantOffset:  0,
+			wantHiddenL: false,
+			wantHiddenR: false,
+		},
+		{
+			name:        "current tab at the end scrolls left",
+			names:       []string{"users", "orders", "products", "invoices", "sessions"},
+			current:     "sessions",
+			width:       36,
+			wantOffset:  2,
+			wantHiddenL: true,
+			wantHiddenR: false,
+		},
+		{
+			name:        "current tab in the middle scrolls right",
+			names:       []string{"users", "orders", "products", "invoices", "sessions"},
+			current:     "products",
+			width:       36,
+			wantOffset:  0,
+			wantHiddenL: false,
+			wantHiddenR: true,
+		},
+		{
+			name:        "tab wider than the strip is still scrolled to it",
+			names:       []string{"a-very-long-tab-name", "b"},
+			current:     "a-very-long-tab-name",
+			width:       10,
+			wantOffset:  0,
+			wantHiddenL: false,
+			wantHiddenR: true,
+		},
+		{
+			name:        "no width keeps the strip at the first column",
+			names:       []string{"users", "orders"},
+			current:     "orders",
+			width:       0,
+			wantOffset:  0,
+			wantHiddenL: false,
+			wantHiddenR: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pane := newTestTabbedPane(t, tt.names...)
+			pane.SetCurrentTab(pane.GetTabByName(tt.current))
+
+			pane.alignHeaderToWidth(tt.width)
+
+			_, offset := pane.HeaderContainer.GetOffset()
+			if offset != tt.wantOffset {
+				t.Errorf("offset = %d, want %d", offset, tt.wantOffset)
+			}
+			if pane.headerHasHiddenLeft != tt.wantHiddenL {
+				t.Errorf("hiddenLeft = %v, want %v", pane.headerHasHiddenLeft, tt.wantHiddenL)
+			}
+			if pane.headerHasHiddenRight != tt.wantHiddenR {
+				t.Errorf("hiddenRight = %v, want %v", pane.headerHasHiddenRight, tt.wantHiddenR)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The issue: #333 


expected behaviour:
```
GIVEN a user is keeping open 10+ tabs of tables
  AND the user's laptop monitor is pretty average: 14 inch Macbook Pro
WHEN the user opens one more table
  AND new tab has been opened at the end of tab menu
THEN the user sees 11th tab opened, highlighted (secondary color)
  AND the 11th tab's name is fully visible
  AND the user doesn't need to zoom out TUI to see the 11th tab
```

#### demo "before/after":

https://github.com/user-attachments/assets/844a3a81-baac-4c9c-8792-b328f537f0b5

