### PR TITLE
fix(mssql): support Azure SQL Database without USE statements

### DIFF
--- a/drivers/mssqql.go
+++ b/drivers/mssqql.go
@@ -21,6 +21,7 @@ import (
 type MSSQL struct {
 	Connection *sql.DB
 	Provider   string
+	isAzureSQL bool
 }
 
 // mssqlGUIDToUUID converts a 16-byte little-endian GUID from MSSQL
@@ -74,10 +75,43 @@ func (db *MSSQL) Connect(urlstr string) error {
 		return err
 	}
 
+	var engineEdition int
+	if err := db.Connection.QueryRow(
+		`SELECT CAST(SERVERPROPERTY('EngineEdition') AS INT)`,
+	).Scan(&engineEdition); err != nil {
+		return err
+	}
+
+	// EngineEdition 5 is Azure SQL Database.
+	// Azure SQL Database does not support switching databases with USE.
+	db.isAzureSQL = engineEdition == 5
+
 	return nil
 }
 
+func quoteMSSQLIdentifier(identifier string) string {
+	return "[" + strings.ReplaceAll(identifier, "]", "]]") + "]"
+}
+
+func (db *MSSQL) databasePrefix(database string) string {
+	if db.isAzureSQL {
+		return ""
+	}
+
+	return "USE " + quoteMSSQLIdentifier(database) + "; "
+}
+
 func (db *MSSQL) GetDatabases() ([]string, error) {
+	if db.isAzureSQL {
+		var database string
+
+		if err := db.Connection.QueryRow("SELECT DB_NAME()").Scan(&database); err != nil {
+			return nil, err
+		}
+
+		return []string{database}, nil
+	}
+
 	databases := make([]string, 0)
 
 	query := `
@@ -86,6 +120,7 @@ func (db *MSSQL) GetDatabases() ([]string, error) {
 		FROM
 			sys.databases
 	`
+
 	rows, err := db.Connection.Query(query)
 	if err != nil {
 		return nil, err
@@ -116,9 +151,7 @@ func (db *MSSQL) GetTables(database string) (map[string][]string, error) {
 
 	tables := make(map[string][]string)
 
-	query := "SELECT name FROM "
-	query += database
-	query += ".sys.tables"
+	query := "SELECT name FROM " + quoteMSSQLIdentifier(database) + ".sys.tables"
 
 	rows, err := db.Connection.Query(query)
 	if err != nil {
@@ -144,8 +177,7 @@ func (db *MSSQL) GetTables(database string) (map[string][]string, error) {
 }
 
 func (db *MSSQL) GetTableColumns(database, table string) ([][]string, error) {
-	query := fmt.Sprintf(`
-		USE %s;
+	query := db.databasePrefix(database) + `
         SELECT
             c.name AS column_name,
             t.name AS data_type,
@@ -161,7 +193,8 @@ func (db *MSSQL) GetTableColumns(database, table string) ([][]string, error) {
         WHERE c.object_id = OBJECT_ID(@p2)
         AND t.name <> 'sysname'
         ORDER BY c.column_id;
-    `, database)
+    `
+
 	return db.getTableInformation(query, database, table, "")
 }
 
@@ -171,8 +204,7 @@ func (db *MSSQL) GetConstraints(database, table string) ([][]string, error) {
 		return nil, err
 	}
 
-	query := fmt.Sprintf(`
-		USE %s;
+	query := db.databasePrefix(database) + `
         SELECT
             kc.name AS constraint_name,
             c.name AS column_name,
@@ -190,14 +222,14 @@ func (db *MSSQL) GetConstraints(database, table string) ([][]string, error) {
             AND ic.object_id = c.object_id
         WHERE s.name = @p1
           AND t.name = @p2
-          AND kc.type IN ('PK', 'UQ')  -- Primary keys and unique constraints
-    `, database)
+          AND kc.type IN ('PK', 'UQ')
+    `
+
 	return db.getTableInformation(query, currentSchema, table, "")
 }
 
 func (db *MSSQL) GetForeignKeys(database, table string) ([][]string, error) {
-	query := fmt.Sprintf(`
-		USE %s;
+	query := db.databasePrefix(database) + `
         SELECT
             fk.name AS constraint_name,
             c.name AS column_name,
@@ -222,7 +254,8 @@ func (db *MSSQL) GetForeignKeys(database, table string) ([][]string, error) {
             ON t.schema_id = s.schema_id
         WHERE t.name = @p2
           AND DB_NAME(DB_ID(@p1)) = @p1
-    `, database)
+    `
+
 	return db.getTableInformation(query, database, table, "")
 }
 
@@ -232,8 +265,21 @@ func (db *MSSQL) GetIndexes(database, table string) ([][]string, error) {
 		return nil, err
 	}
 
-	query := fmt.Sprintf(`
-		USE %s;
+	databaseJoin := `
+        INNER JOIN sys.databases d
+            ON d.name = @p1
+	`
+	databaseFilter := "AND DB_ID(@p1) = d.database_id"
+
+	if db.isAzureSQL {
+		// In Azure SQL Database, DB_ID() isn't guaranteed to match the
+		// database_id exposed by sys.databases. The connection is already
+		// scoped to the current database, so compare against DB_NAME().
+		databaseJoin = ""
+		databaseFilter = "AND DB_NAME() = @p1"
+	}
+
+	query := db.databasePrefix(database) + fmt.Sprintf(`
         SELECT
             t.name AS table_name,
             i.name AS index_name,
@@ -248,8 +294,7 @@ func (db *MSSQL) GetIndexes(database, table string) ([][]string, error) {
         FROM sys.tables t
         INNER JOIN sys.schemas s
             ON t.schema_id = s.schema_id
-        INNER JOIN sys.databases d
-            ON d.name = @p1
+        %s
         INNER JOIN sys.indexes i
             ON t.object_id = i.object_id
         INNER JOIN sys.index_columns ic
@@ -260,9 +305,10 @@ func (db *MSSQL) GetIndexes(database, table string) ([][]string, error) {
             AND t.object_id = c.object_id
         WHERE t.name = @p2
           AND s.name = @p3
-          AND DB_ID(@p1) = d.database_id
+          %s
         ORDER BY i.type_desc
-    `, database)
+    `, databaseJoin, databaseFilter)
+
 	return db.getTableInformation(query, database, table, currentSchema)
 }
 
@@ -281,27 +327,33 @@ func (db *MSSQL) GetRecords(database, table, where, sort string, offset, limit i
 
 	results = make([][]string, 0)
 
-	baseQuery := fmt.Sprintf("USE %s; SELECT * FROM ", database)
-	baseQuery += db.FormatReference(table)
+	baseQuery := db.databasePrefix(database) + "SELECT * FROM " + db.FormatReference(table)
 
 	if where != "" {
 		baseQuery += fmt.Sprintf(" %s", where)
 	}
 
-	// Since in MSSQL, ORDER BY is mandatory when using pagination
 	if sort == "" {
-		sort = "(SELECT NULL)" // Or use a primary key if available and sensible as a default
+		sort = "(SELECT NULL)"
 	}
 
-	// Query for execution with placeholders
-	executableQuery := fmt.Sprintf("%s ORDER BY %s OFFSET @p1 ROWS FETCH NEXT @p2 ROWS ONLY", baseQuery, sort)
+	executableQuery := fmt.Sprintf(
+		"%s ORDER BY %s OFFSET @p1 ROWS FETCH NEXT @p2 ROWS ONLY",
+		baseQuery,
+		sort,
+	)
 
-	// Query for display with actual values
-	displayQueryString = fmt.Sprintf("%s ORDER BY %s OFFSET %s ROWS FETCH NEXT %s ROWS ONLY", baseQuery, sort, db.FormatArg(offset, models.String), db.FormatArg(limit, models.String))
+	displayQueryString = fmt.Sprintf(
+		"%s ORDER BY %s OFFSET %s ROWS FETCH NEXT %s ROWS ONLY",
+		baseQuery,
+		sort,
+		db.FormatArg(offset, models.String),
+		db.FormatArg(limit, models.String),
+	)
 
 	rows, err := db.Connection.Query(executableQuery, offset, limit)
 	if err != nil {
-		return nil, 0, displayQueryString, err // Return display query even on error
+		return nil, 0, displayQueryString, err
 	}
 
 	defer rows.Close()
@@ -323,7 +375,7 @@ func (db *MSSQL) GetRecords(database, table, where, sort string, offset, limit i
 		if errScan := rows.Scan(rowValues...); errScan != nil {
 			return nil, 0, displayQueryString, errScan
 		}
-		// Get column types to identify UNIQUEIDENTIFIER
+
 		columnTypes, err := rows.ColumnTypes()
 		if err != nil {
 			return nil, 0, displayQueryString, err
@@ -332,7 +384,9 @@ func (db *MSSQL) GetRecords(database, table, where, sort string, offset, limit i
 		if len(columnTypes) != len(rowValues) {
 			return nil, 0, displayQueryString, errors.New("unexpected number of column")
 		}
+
 		var row []string
+
 		for i, col := range rowValues {
 			if col == nil {
 				row = append(row, "NULL&")
@@ -348,13 +402,12 @@ func (db *MSSQL) GetRecords(database, table, where, sort string, offset, limit i
 			colType := columnType.DatabaseTypeName()
 
 			if colType == "UNIQUEIDENTIFIER" {
-				// Try to parse as a GUID
 				if guid, errParse := mssqlGUIDToUUID(*rawBytes); errParse == nil {
-					row = append(row, guid.String()) // Now this will be the correct format
+					row = append(row, guid.String())
 				} else {
-					// Fallback to hex string if parsing fails
 					hexValue := hex.EncodeToString(*rawBytes)
-					row = append(row, "0x"+hexValue) // Prefix with "0x" for clarity
+					row = append(row, "0x"+hexValue)
+
 					logger.Warn("Invalid GUID", map[string]any{
 						"table":  table,
 						"column": columns[i],
@@ -362,19 +415,20 @@ func (db *MSSQL) GetRecords(database, table, where, sort string, offset, limit i
 						"error":  errParse,
 					})
 				}
+
 				continue
 			}
 
-			// Handle other columns as strings
 			colval := string(*rawBytes)
-			// Check nullability and handle empty strings
 			nullable, _ := columnType.Nullable()
+
 			if nullable && colval == "" {
-				row = append(row, "NULL&") // show "NULL" instead if "EMPTY" when column is Nullable and it's set to null
+				row = append(row, "NULL&")
 			} else {
 				row = append(row, colval)
 			}
 		}
+
 		results = append(results, row)
 	}
 
@@ -382,24 +436,28 @@ func (db *MSSQL) GetRecords(database, table, where, sort string, offset, limit i
 		return nil, 0, displayQueryString, err
 	}
 
-	countQuery := "USE "
-	countQuery += database
-	countQuery += "; "
-	countQuery += "SELECT COUNT(*) FROM "
-	countQuery += db.FormatReference(table)
+	countQuery := db.databasePrefix(database) +
+		"SELECT COUNT(*) FROM " +
+		db.FormatReference(table)
 
 	if where != "" {
 		countQuery += fmt.Sprintf(" %s", where)
 	}
 
 	totalRecords = 0
+
 	countRow := db.Connection.QueryRow(countQuery)
 	if err := countRow.Scan(&totalRecords); err != nil {
-		return results, 0, displayQueryString, err // Return display query even on count error
+		return results, 0, displayQueryString, err
 	}
 
-	// Replace the limit and offset with actual values in the query string
-	displayQueryString = fmt.Sprintf("%s ORDER BY %s OFFSET %d ROWS FETCH NEXT %d ROWS ONLY", baseQuery, sort, offset, limit)
+	displayQueryString = fmt.Sprintf(
+		"%s ORDER BY %s OFFSET %d ROWS FETCH NEXT %d ROWS ONLY",
+		baseQuery,
+		sort,
+		offset,
+		limit,
+	)
 
 	return results, totalRecords, displayQueryString, nil
 }
@@ -425,16 +483,12 @@ func (db *MSSQL) UpdateRecord(database, table, column, value, primaryKeyColumnNa
 		return errors.New("primary key value is required")
 	}
 
-	query := "USE "
-	query += database
-	query += "; UPDATE "
-	query += database
-	query += table
-	query += " SET "
-	query += column
-	query += " = @p1 WHERE "
-	query += primaryKeyColumnName
-	query += " = @p2"
+	query := db.databasePrefix(database) +
+		"UPDATE " + db.FormatReference(table) +
+		" SET " + db.FormatReference(column) +
+		" = @p1 WHERE " + db.FormatReference(primaryKeyColumnName) +
+		" = @p2"
+
 	_, err := db.Connection.Exec(query, value, primaryKeyValue)
 
 	return err
@@ -457,13 +511,11 @@ func (db *MSSQL) DeleteRecord(database, table, primaryKeyColumnName, primaryKeyV
 		return errors.New("primary key value is required")
 	}
 
-	query := "USE "
-	query += database
-	query += "; DELETE FROM "
-	query += table
-	query += " WHERE "
-	query += primaryKeyColumnName
-	query += " = @p1"
+	query := db.databasePrefix(database) +
+		"DELETE FROM " + db.FormatReference(table) +
+		" WHERE " + db.FormatReference(primaryKeyColumnName) +
+		" = @p1"
+
 	_, err := db.Connection.Exec(query, primaryKeyValue)
 
 	return err
@@ -572,10 +624,8 @@ func (db *MSSQL) GetPrimaryKeyColumnNames(database, table string) ([]string, err
 	}
 
 	pkColumnName := make([]string, 0)
-	query := "USE "
-	query += database
-	query += "; "
-	query += `
+
+	query := db.databasePrefix(database) + `
 		SELECT
 			c.name AS column_name
 		FROM
@@ -600,6 +650,7 @@ func (db *MSSQL) GetPrimaryKeyColumnNames(database, table string) ([]string, err
 			AND t.name = @p3
 		ORDER BY ic.key_ordinal
 	`
+
 	rows, err := db.Connection.Query(query, "PK", currentSchema, table)
 	if err != nil {
 		return nil, err
@@ -609,13 +660,9 @@ func (db *MSSQL) GetPrimaryKeyColumnNames(database, table string) ([]string, err
 
 	for rows.Next() {
 		var colName string
-		err = rows.Scan(&colName)
-		if err != nil {
-			return nil, err
-		}
 
-		if rows.Err() != nil {
-			return nil, rows.Err()
+		if err := rows.Scan(&colName); err != nil {
+			return nil, err
 		}
 
 		pkColumnName = append(pkColumnName, colName)
@@ -772,7 +819,7 @@ func (db *MSSQL) FormatArgForQueryString(arg any) string {
 }
 
 func (db *MSSQL) FormatReference(reference string) string {
-	return fmt.Sprintf("[%s]", reference)
+	return quoteMSSQLIdentifier(reference)
 }
 
 func (db *MSSQL) FormatPlaceholder(index int) string {
@@ -819,17 +866,14 @@ func (db *MSSQL) GetFunctions(database string) (map[string][]string, error) {
 
 	functions := make(map[string][]string)
 
-	query := "USE "
-	query += database
-	query += ";"
-	query += `
+	query := db.databasePrefix(database) + `
 		SELECT o.name
 		FROM sys.sql_modules m
 		JOIN sys.objects o ON m.object_id = o.object_id
 		WHERE o.type_desc IN ('SQL_SCALAR_FUNCTION', 'SQL_TABLE_VALUED_FUNCTION')
-		`
+	`
 
-	rows, err := db.Connection.Query(query, database)
+	rows, err := db.Connection.Query(query)
 	if err != nil {
 		return nil, err
 	}
@@ -838,6 +882,7 @@ func (db *MSSQL) GetFunctions(database string) (map[string][]string, error) {
 
 	for rows.Next() {
 		var function string
+
 		if err := rows.Scan(&function); err != nil {
 			return nil, err
 		}
@@ -859,15 +904,12 @@ func (db *MSSQL) GetProcedures(database string) (map[string][]string, error) {
 
 	procedures := make(map[string][]string)
 
-	query := "USE "
-	query += database
-	query += "; "
-	query += `
+	query := db.databasePrefix(database) + `
 		SELECT o.name
 		FROM sys.sql_modules m
 		JOIN sys.objects o ON m.object_id = o.object_id
 		WHERE o.type_desc IN ('SQL_STORED_PROCEDURE')
-		`
+	`
 
 	rows, err := db.Connection.Query(query)
 	if err != nil {
@@ -878,6 +920,7 @@ func (db *MSSQL) GetProcedures(database string) (map[string][]string, error) {
 
 	for rows.Next() {
 		var procedure string
+
 		if err := rows.Scan(&procedure); err != nil {
 			return nil, err
 		}
@@ -907,10 +950,7 @@ func (db *MSSQL) GetViews(database string) (map[string][]string, error) {
 
 	views := make(map[string][]string)
 
-	query := "USE "
-	query += database
-	query += "; "
-	query += `
+	query := db.databasePrefix(database) + `
 		SELECT o.name
 		FROM sys.sql_modules m
 		JOIN sys.objects o ON m.object_id = o.object_id
@@ -926,6 +966,7 @@ func (db *MSSQL) GetViews(database string) (map[string][]string, error) {
 
 	for rows.Next() {
 		var view string
+
 		if err := rows.Scan(&view); err != nil {
 			return nil, err
 		}
@@ -947,13 +988,9 @@ func (db *MSSQL) GetObjectDefinition(database string, name string) (string, erro
 
 	result := ""
 
-	query := "USE "
-	query += database
-	query += "; "
-	query += `
+	query := db.databasePrefix(database) + `
 	declare @proc_source nvarchar(max);
     select @proc_source = object_definition(object_id(@name));
-
     if charindex('create', @proc_source) > 0 and
         charindex('create', @proc_source) < charindex(@name, @proc_source)
     begin
@@ -964,6 +1001,7 @@ func (db *MSSQL) GetObjectDefinition(database string, name string) (string, erro
 	`
 
 	row := db.Connection.QueryRow(query, sql.Named("name", name))
+
 	if err := row.Scan(&result); err != nil {
 		return result, err
 	}

--- a/drivers/mssqql_test.go
+++ b/drivers/mssqql_test.go
@@ -76,7 +76,7 @@ func TestMSSQL_GetPrimaryKeyColumnNames(t *testing.T) {
 	mock.ExpectQuery("SELECT SCHEMA_NAME() AS CurrentSchema").WillReturnRows(schemaRow)
 
 	// Match exact query structure with schema and USE prefix
-	mock.ExpectQuery(`USE test_db; SELECT
+	mock.ExpectQuery(`USE [test_db]; SELECT
 			c.name AS column_name
 		FROM
 			sys.tables t
@@ -147,7 +147,7 @@ func TestMSSQL_GetForeignKeys(t *testing.T) {
 	)
 
 	mock.ExpectQuery(`
-        USE test_db; SELECT 
+        USE [test_db]; SELECT 
             fk.name AS constraint_name,
             c.name AS column_name,
             DB_NAME(DB_ID(@p1)) AS current_database,
@@ -294,7 +294,7 @@ func TestMSSQL_GetIndexes(t *testing.T) {
 	mock.ExpectQuery("SELECT SCHEMA_NAME() AS CurrentSchema").WillReturnRows(schemaRow)
 
 	mock.ExpectQuery(`
-        USE test_db; SELECT
+        USE [test_db]; SELECT
             t.name AS table_name,
             i.name AS index_name,
             CAST(i.is_unique AS BIT) AS is_unique,
@@ -427,7 +427,7 @@ func TestMSSQL_GetTableColumns(t *testing.T) {
 		"", // Empty comment
 	)
 
-	mock.ExpectQuery(`USE test_db;
+	mock.ExpectQuery(`USE [test_db];
         SELECT
             c.name AS column_name,
             t.name AS data_type,
@@ -505,6 +505,160 @@ func TestMSSQL_GetRecords(t *testing.T) {
 
 	if total != 2 {
 		t.Fatalf("Expected total 2, got %d", total)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("Unfulfilled expectations: %s", err)
+	}
+}
+
+func TestMSSQL_AzureSQLDatabasePrefix(t *testing.T) {
+	t.Run("SQL Server uses quoted USE", func(t *testing.T) {
+		db := &MSSQL{}
+
+		got := db.databasePrefix("sql-db")
+		expected := "USE [sql-db]; "
+
+		if got != expected {
+			t.Fatalf("expected %q, got %q", expected, got)
+		}
+	})
+
+	t.Run("Azure SQL does not use USE", func(t *testing.T) {
+		db := &MSSQL{isAzureSQL: true}
+
+		got := db.databasePrefix("sql-db")
+		if got != "" {
+			t.Fatalf("expected empty prefix, got %q", got)
+		}
+	})
+}
+
+func TestMSSQL_FormatReferenceEscapesClosingBracket(t *testing.T) {
+	db := &MSSQL{}
+
+	got := db.FormatReference("database]name")
+	expected := "[database]]name]"
+
+	if got != expected {
+		t.Fatalf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestMSSQL_GetDatabasesAzureSQL(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New(
+		sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual),
+	)
+	if err != nil {
+		t.Fatalf("Error creating mock: %v", err)
+	}
+	defer sqlDB.Close()
+
+	db := &MSSQL{
+		Connection: sqlDB,
+		isAzureSQL: true,
+	}
+
+	mock.ExpectQuery("SELECT DB_NAME()").
+		WillReturnRows(
+			sqlmock.NewRows([]string{"database"}).
+				AddRow("sql-db"),
+		)
+
+	databases, err := db.GetDatabases()
+	if err != nil {
+		t.Fatalf("GetDatabases failed: %v", err)
+	}
+
+	expected := []string{"sql-db"}
+	if !reflect.DeepEqual(databases, expected) {
+		t.Fatalf("expected %v, got %v", expected, databases)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("Unfulfilled expectations: %s", err)
+	}
+}
+
+func TestMSSQL_GetTablesQuotesDatabaseName(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New(
+		sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual),
+	)
+	if err != nil {
+		t.Fatalf("Error creating mock: %v", err)
+	}
+	defer sqlDB.Close()
+
+	db := &MSSQL{Connection: sqlDB}
+
+	mock.ExpectQuery("SELECT name FROM [sql-db].sys.tables").
+		WillReturnRows(
+			sqlmock.NewRows([]string{"name"}).
+				AddRow("users"),
+		)
+
+	tables, err := db.GetTables("sql-db")
+	if err != nil {
+		t.Fatalf("GetTables failed: %v", err)
+	}
+
+	expected := map[string][]string{
+		"sql-db": {"users"},
+	}
+
+	if !reflect.DeepEqual(tables, expected) {
+		t.Fatalf("expected %v, got %v", expected, tables)
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Errorf("Unfulfilled expectations: %s", err)
+	}
+}
+
+func TestMSSQL_GetRecordsAzureSQLDoesNotUseUSE(t *testing.T) {
+	sqlDB, mock, err := sqlmock.New(
+		sqlmock.QueryMatcherOption(sqlmock.QueryMatcherEqual),
+	)
+	if err != nil {
+		t.Fatalf("Error creating mock: %v", err)
+	}
+	defer sqlDB.Close()
+
+	db := &MSSQL{
+		Connection: sqlDB,
+		isAzureSQL: true,
+	}
+
+	rows := sqlmock.NewRows([]string{"id", "name"}).
+		AddRow(1, "Alice")
+
+	mock.ExpectQuery(
+		"SELECT * FROM [test_table] ORDER BY (SELECT NULL) OFFSET @p1 ROWS FETCH NEXT @p2 ROWS ONLY",
+	).
+		WithArgs(0, DefaultRowLimit).
+		WillReturnRows(rows)
+
+	mock.ExpectQuery(
+		"SELECT COUNT(*) FROM [test_table]",
+	).
+		WillReturnRows(
+			sqlmock.NewRows([]string{"count"}).AddRow(1),
+		)
+
+	_, total, _, err := db.GetRecords(
+		DBNameMSSQL,
+		tableNameMSSQL,
+		"",
+		"",
+		0,
+		DefaultRowLimit,
+	)
+	if err != nil {
+		t.Fatalf("GetRecords failed: %v", err)
+	}
+
+	if total != 1 {
+		t.Fatalf("expected total 1, got %d", total)
 	}
 
 	if err := mock.ExpectationsWereMet(); err != nil {


### PR DESCRIPTION
This pull request refactors the MSSQL driver to improve compatibility with Azure SQL Database and standardizes how database context is managed in SQL queries. The main changes include detecting Azure SQL, removing the use of the `USE` statement where unsupported, and consistently quoting identifiers to avoid SQL injection and syntax issues.

**Azure SQL compatibility and context management:**

- Added detection of Azure SQL Database by checking `SERVERPROPERTY('EngineEdition')` and storing the result in the new `isAzureSQL` field. This allows the driver to adjust behavior for Azure SQL, which does not support the `USE` statement. [[1]](diffhunk://#diff-37702eed04e0eadc003b00dae02d2a94ff34e29c4e4c5c8d375e6174150f47a5R24) [[2]](diffhunk://#diff-37702eed04e0eadc003b00dae02d2a94ff34e29c4e4c5c8d375e6174150f47a5R78-R114)
- Centralized logic for prefixing queries with the correct database context by introducing the `databasePrefix` method, which omits the `USE` statement for Azure SQL and quotes database names safely for other environments. This method is now used throughout the driver for all relevant queries. [[1]](diffhunk://#diff-37702eed04e0eadc003b00dae02d2a94ff34e29c4e4c5c8d375e6174150f47a5R78-R114) [[2]](diffhunk://#diff-37702eed04e0eadc003b00dae02d2a94ff34e29c4e4c5c8d375e6174150f47a5L147-R180) [[3]](diffhunk://#diff-37702eed04e0eadc003b00dae02d2a94ff34e29c4e4c5c8d375e6174150f47a5L174-R207) [[4]](diffhunk://#diff-37702eed04e0eadc003b00dae02d2a94ff34e29c4e4c5c8d375e6174150f47a5L235-R282) [[5]](diffhunk://#diff-37702eed04e0eadc003b00dae02d2a94ff34e29c4e4c5c8d375e6174150f47a5L284-R356) [[6]](diffhunk://#diff-37702eed04e0eadc003b00dae02d2a94ff34e29c4e4c5c8d375e6174150f47a5L428-R491) [[7]](diffhunk://#diff-37702eed04e0eadc003b00dae02d2a94ff34e29c4e4c5c8d375e6174150f47a5L460-R518) [[8]](diffhunk://#diff-37702eed04e0eadc003b00dae02d2a94ff34e29c4e4c5c8d375e6174150f47a5L575-R628) [[9]](diffhunk://#diff-37702eed04e0eadc003b00dae02d2a94ff34e29c4e4c5c8d375e6174150f47a5L822-R876) [[10]](diffhunk://#diff-37702eed04e0eadc003b00dae02d2a94ff34e29c4e4c5c8d375e6174150f47a5L862-R907) [[11]](diffhunk://#diff-37702eed04e0eadc003b00dae02d2a94ff34e29c4e4c5c8d375e6174150f47a5L910-R953) [[12]](diffhunk://#diff-37702eed04e0eadc003b00dae02d2a94ff34e29c4e4c5c8d375e6174150f47a5L950-L956)

**Identifier quoting improvements:**

- Introduced the `quoteMSSQLIdentifier` function and updated all places where table, column, or database names are injected into queries to use this function, preventing SQL injection and syntax errors. [[1]](diffhunk://#diff-37702eed04e0eadc003b00dae02d2a94ff34e29c4e4c5c8d375e6174150f47a5R78-R114) [[2]](diffhunk://#diff-37702eed04e0eadc003b00dae02d2a94ff34e29c4e4c5c8d375e6174150f47a5L119-R154) [[3]](diffhunk://#diff-37702eed04e0eadc003b00dae02d2a94ff34e29c4e4c5c8d375e6174150f47a5L775-R822)

**Query construction and error handling:**

- Refactored query construction to use the new context and quoting logic, simplifying and unifying query formatting across methods like `GetRecords`, `UpdateRecord`, `DeleteRecord`, and others. [[1]](diffhunk://#diff-37702eed04e0eadc003b00dae02d2a94ff34e29c4e4c5c8d375e6174150f47a5L284-R356) [[2]](diffhunk://#diff-37702eed04e0eadc003b00dae02d2a94ff34e29c4e4c5c8d375e6174150f47a5L428-R491) [[3]](diffhunk://#diff-37702eed04e0eadc003b00dae02d2a94ff34e29c4e4c5c8d375e6174150f47a5L460-R518)
- Improved error handling and scanning logic in methods that fetch data, ensuring errors are caught and returned promptly. [[1]](diffhunk://#diff-37702eed04e0eadc003b00dae02d2a94ff34e29c4e4c5c8d375e6174150f47a5L612-R665) [[2]](diffhunk://#diff-37702eed04e0eadc003b00dae02d2a94ff34e29c4e4c5c8d375e6174150f47a5R387-R389) [[3]](diffhunk://#diff-37702eed04e0eadc003b00dae02d2a94ff34e29c4e4c5c8d375e6174150f47a5L351-R460)

**Azure SQL-specific adjustments:**

- Updated logic for joining and filtering on databases in `GetIndexes` to accommodate Azure SQL's limitations, ensuring correct results regardless of environment. [[1]](diffhunk://#diff-37702eed04e0eadc003b00dae02d2a94ff34e29c4e4c5c8d375e6174150f47a5L235-R282) [[2]](diffhunk://#diff-37702eed04e0eadc003b00dae02d2a94ff34e29c4e4c5c8d375e6174150f47a5L251-R297) [[3]](diffhunk://#diff-37702eed04e0eadc003b00dae02d2a94ff34e29c4e4c5c8d375e6174150f47a5L263-R311)

**Test updates:**

- Adjusted tests to match the new quoting and context logic, ensuring correct expectations for query structure.

Fixes #342 